### PR TITLE
[#10] 리뷰 거절 기능 구현

### DIFF
--- a/src/main/java/project/reviewing/review/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/application/ReviewService.java
@@ -48,7 +48,7 @@ public class ReviewService {
         final Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(ReviewNotFoundException::new);
 
-        review.updateReview(revieweeId, request.getContent());
+        review.update(revieweeId, request.getContent());
     }
 
     public void acceptReview(final Long memberId, final Long reviewId) {
@@ -57,7 +57,7 @@ public class ReviewService {
         final Member reviewerMember = memberRepository.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
-        review.acceptReview(reviewerMember.getReviewer().getId());
+        review.accept(reviewerMember.getReviewer().getId());
     }
 
     public void refuseReview(final Long memberId, final Long reviewId) {

--- a/src/main/java/project/reviewing/review/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/application/ReviewService.java
@@ -38,36 +38,40 @@ public class ReviewService {
 
     @Transactional(readOnly = true)
     public SingleReviewReadResponse readSingleReview(final Long reviewId) {
-        final Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(ReviewNotFoundException::new);
+        final Review review = findReviewById(reviewId);
 
         return SingleReviewReadResponse.from(review);
     }
 
     public void updateReview(final Long revieweeId, final Long reviewId, final ReviewUpdateRequest request) {
-        final Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(ReviewNotFoundException::new);
+        final Review review = findReviewById(reviewId);
 
         review.update(revieweeId, request.getContent());
     }
 
     public void acceptReview(final Long memberId, final Long reviewId) {
-        final Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(ReviewNotFoundException::new);
-        final Member reviewerMember = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        final Review review = findReviewById(reviewId);
+        final Member reviewerMember = findMemberById(memberId);
 
         review.accept(reviewerMember.getReviewer().getId());
     }
 
     public void refuseReview(final Long memberId, final Long reviewId) {
-        final Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(ReviewNotFoundException::new);
-        final Member reviewerMember = memberRepository.findById(memberId)
-                .orElseThrow(MemberNotFoundException::new);
+        final Review review = findReviewById(reviewId);
+        final Member reviewerMember = findMemberById(memberId);
 
         if (review.canRefuse(reviewerMember.getReviewer().getId())) {
             reviewRepository.delete(review);
         }
+    }
+
+    private Review findReviewById(final Long id) {
+        return reviewRepository.findById(id)
+                .orElseThrow(ReviewNotFoundException::new);
+    }
+
+    private Member findMemberById(final Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/src/main/java/project/reviewing/review/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/application/ReviewService.java
@@ -59,4 +59,15 @@ public class ReviewService {
 
         review.acceptReview(reviewerMember.getReviewer().getId());
     }
+
+    public void refuseReview(final Long memberId, final Long reviewId) {
+        final Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(ReviewNotFoundException::new);
+        final Member reviewerMember = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        if (review.canRefuse(reviewerMember.getReviewer().getId())) {
+            reviewRepository.delete(review);
+        }
+    }
 }

--- a/src/main/java/project/reviewing/review/domain/Review.java
+++ b/src/main/java/project/reviewing/review/domain/Review.java
@@ -64,7 +64,17 @@ public class Review {
         if (!status.equals(ReviewStatus.CREATED)) {
             throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
         }
-        this.status = ReviewStatus.ACCEPTED;
+        status = ReviewStatus.ACCEPTED;
+    }
+
+    public boolean canRefuse(final Long reviewerId) {
+        if (!this.reviewerId.equals(reviewerId)) {
+            throw new InvalidReviewException(ErrorType.NOT_REVIEWER_OF_REVIEW);
+        }
+        if (!status.equals(ReviewStatus.CREATED)) {
+            throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
+        }
+        return true;
     }
 
     private Review(

--- a/src/main/java/project/reviewing/review/domain/Review.java
+++ b/src/main/java/project/reviewing/review/domain/Review.java
@@ -50,14 +50,14 @@ public class Review {
         return new Review(revieweeId, reviewerId, title, content, prUrl, ReviewStatus.CREATED);
     }
 
-    public void updateReview(final Long revieweeId, final String updatingContent) {
+    public void update(final Long revieweeId, final String updatingContent) {
         if (!this.revieweeId.equals(revieweeId)) {
             throw new InvalidReviewException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
         }
         this.content = updatingContent;
     }
 
-    public void acceptReview(final Long reviewerId) {
+    public void accept(final Long reviewerId) {
         checkReviewer(reviewerId);
         checkStatusCreated();
         status = ReviewStatus.ACCEPTED;

--- a/src/main/java/project/reviewing/review/domain/Review.java
+++ b/src/main/java/project/reviewing/review/domain/Review.java
@@ -58,23 +58,27 @@ public class Review {
     }
 
     public void acceptReview(final Long reviewerId) {
-        if (!this.reviewerId.equals(reviewerId)) {
-            throw new InvalidReviewException(ErrorType.NOT_REVIEWER_OF_REVIEW);
-        }
-        if (!status.equals(ReviewStatus.CREATED)) {
-            throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
-        }
+        checkReviewer(reviewerId);
+        checkStatusCreated();
         status = ReviewStatus.ACCEPTED;
     }
 
     public boolean canRefuse(final Long reviewerId) {
+        checkReviewer(reviewerId);
+        checkStatusCreated();
+        return true;
+    }
+
+    private void checkReviewer(final Long reviewerId) {
         if (!this.reviewerId.equals(reviewerId)) {
             throw new InvalidReviewException(ErrorType.NOT_REVIEWER_OF_REVIEW);
         }
+    }
+
+    private void checkStatusCreated() {
         if (!status.equals(ReviewStatus.CREATED)) {
             throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
         }
-        return true;
     }
 
     private Review(

--- a/src/main/java/project/reviewing/review/domain/ReviewRepository.java
+++ b/src/main/java/project/reviewing/review/domain/ReviewRepository.java
@@ -10,4 +10,5 @@ public interface ReviewRepository extends Repository<Review, Long> {
     Optional<Review> findById(Long id);
     Optional<Review> findByRevieweeIdAndReviewerId(Long revieweeId, Long reviewerId);
     Boolean existsByRevieweeIdAndReviewerId(Long revieweeId, Long reviewerId);
+    void delete(Review entity);
 }

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -50,4 +50,12 @@ public class ReviewController {
     ) {
         reviewService.acceptReview(memberId, reviewId);
     }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{review-id}")
+    public void refuseReview(
+            @AuthenticatedMember final Long memberId,
+            @PathVariable("review-id") final Long reviewId
+    ) {
+    }
 }

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -57,5 +57,6 @@ public class ReviewController {
             @AuthenticatedMember final Long memberId,
             @PathVariable("review-id") final Long reviewId
     ) {
+        reviewService.refuseReview(memberId, reviewId);
     }
 }

--- a/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
+++ b/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
@@ -218,4 +218,62 @@ public class ReviewServiceTest extends IntegrationTest {
                     .isInstanceOf(MemberNotFoundException.class);
         }
     }
+
+    @DisplayName("리뷰 거절 시")
+    @Nested
+    class ReviewRefuseTest {
+
+        @DisplayName("정상적으로 거절된다.")
+        @Test
+        void validRefuseReview() {
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer()
+                    ));
+
+            reviewService.refuseReview(reviewerMember.getId(), review.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            assertThat(reviewRepository.findById(review.getId())).isEmpty();
+        }
+
+        @DisplayName("리뷰 정보가 없으면 예외 발생한다.")
+        @Test
+        void refuseWithNotExistReview() {
+            final Long invalidReviewId = -1L;
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+
+            assertThatThrownBy(() -> reviewService.refuseReview(reviewerMember.getId(), invalidReviewId))
+                    .isInstanceOf(ReviewNotFoundException.class);
+        }
+
+        @DisplayName("요청한 회원 정보가 없으면 예외 발생한다.")
+        @Test
+        void refuseWithNotExistMember() {
+            final Long invalidMemberId = -1L;
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer()
+                    ));
+
+            assertThatThrownBy(() -> reviewService.refuseReview(invalidMemberId, review.getId()))
+                    .isInstanceOf(MemberNotFoundException.class);
+        }
+    }
 }

--- a/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
+++ b/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
@@ -45,7 +45,7 @@ public class ReviewTest {
         final String updatingContent = "새 본문";
         final Review review = Review.assign(1L, 2L, "제목", "본문", "github.com/bboor/project/pull/1", 2L, true);
 
-        review.updateReview(1L, updatingContent);
+        review.update(1L, updatingContent);
 
         assertThat(review.getContent()).isEqualTo(updatingContent);
     }
@@ -57,7 +57,7 @@ public class ReviewTest {
         final Long invalidRevieweeId = 2L;
         final Review review = Review.assign(revieweeId, 2L, "제목", "본문", "github.com/bboor/project/pull/1", 2L, true);
 
-        assertThatThrownBy(() -> review.updateReview(invalidRevieweeId, "새 본문"))
+        assertThatThrownBy(() -> review.update(invalidRevieweeId, "새 본문"))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_REVIEWEE_OF_REVIEW.getMessage());
     }
@@ -67,7 +67,7 @@ public class ReviewTest {
     void validAcceptReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
 
-        review.acceptReview(1L);
+        review.accept(1L);
 
         assertThat(review.getStatus()).isEqualTo(ReviewStatus.ACCEPTED);
     }
@@ -77,7 +77,7 @@ public class ReviewTest {
     void acceptWithNotReviewerOfReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
 
-        assertThatThrownBy(() -> review.acceptReview(2L))
+        assertThatThrownBy(() -> review.accept(2L))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
     }
@@ -87,9 +87,9 @@ public class ReviewTest {
     void acceptWithNotProperStatus() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
 
-        review.acceptReview(1L);
+        review.accept(1L);
 
-        assertThatThrownBy(() -> review.acceptReview(1L))
+        assertThatThrownBy(() -> review.accept(1L))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
     }
@@ -117,7 +117,7 @@ public class ReviewTest {
     void refuseWithNotProperStatus() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
 
-        review.acceptReview(1L); // Accepted 상태로 변경
+        review.accept(1L); // Accepted 상태로 변경
 
         assertThatThrownBy(() -> review.canRefuse(1L))
                 .isInstanceOf(InvalidReviewException.class)

--- a/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
+++ b/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
@@ -93,4 +93,34 @@ public class ReviewTest {
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
     }
+
+    @DisplayName("리뷰를 거절할 수 있는지 조건을 확인할 수 있다.")
+    @Test
+    void validRefuseReview() {
+        final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
+
+        assertThat(review.canRefuse(1L)).isTrue();
+    }
+
+    @DisplayName("리뷰를 요청받은 리뷰어가 아니면 거절할 수 없다.")
+    @Test
+    void refuseWithNotReviewerOfReview() {
+        final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
+
+        assertThatThrownBy(() -> review.canRefuse(2L))
+                .isInstanceOf(InvalidReviewException.class)
+                .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
+    }
+
+    @DisplayName("리뷰의 상태가 CREATED(생성) 상태가 아니면 거절할 수 없다.")
+    @Test
+    void refuseWithNotProperStatus() {
+        final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true);
+
+        review.acceptReview(1L); // Accepted 상태로 변경
+
+        assertThatThrownBy(() -> review.canRefuse(1L))
+                .isInstanceOf(InvalidReviewException.class)
+                .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
+    }
 }

--- a/src/test/java/project/reviewing/unit/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/project/reviewing/unit/review/presentation/ReviewControllerTest.java
@@ -197,10 +197,22 @@ public class ReviewControllerTest extends ControllerTest {
     @Nested
     class ReviewAcceptTest {
 
-        @DisplayName("요청이 유효하면 200 반환한다.")
+        @DisplayName("요청이 유효하면 204 반환한다.")
         @Test
         void validAcceptReview() throws Exception {
             requestAboutReview(patch("/reviewers/1/reviews/1/status-accepted"), null)
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    @DisplayName("리뷰 거절 시")
+    @Nested
+    class ReviewRefuseTest {
+
+        @DisplayName("요청이 유효하면 204 반환한다.")
+        @Test
+        void validAcceptReview() throws Exception {
+            requestAboutReview(delete("/reviewers/1/reviews/1"), null)
                     .andExpect(status().isNoContent());
         }
     }


### PR DESCRIPTION
## 상세 내용

- 리뷰 거절 API 개발
  - 요청한 유저가 리뷰의 리뷰어가 아니면 예외 발생
  - 리뷰 상태가 Created (생성) 인 경우에만 거절 가능
- 테스트 코드 작성
- 리팩터링
   - 중복 로직 Method로 추출, Method명 변경

## 주의 사항

- 현재는 바로 삭제되지만, 이후에 거절당한 리뷰를 리뷰이가 확인할 수 있는 방향으로 기획 변경 및 구현 예정

Close #10