### PR TITLE
[#23] 내 리뷰 목록 조회 시 리뷰 상태에 따라 필터링 구현

### DIFF
--- a/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 
 public enum ReviewStatus {
 
+    NONE,
     CREATED,
     ACCEPTED,
     APPROVED,
@@ -12,5 +13,13 @@ public enum ReviewStatus {
     public static boolean isContain(final String name) {
         return Arrays.stream(values())
                 .anyMatch(status -> status.name().equals(name));
+    }
+
+    public static ReviewStatus of(final String name) {
+        return (name == null) ? ReviewStatus.NONE : ReviewStatus.valueOf(name);
+    }
+
+    public boolean isNone() {
+        return this.equals(NONE);
     }
 }

--- a/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
@@ -1,15 +1,16 @@
 package project.reviewing.review.command.domain;
 
+import java.util.Arrays;
+
 public enum ReviewStatus {
 
-    CREATED("생성"),
-    ACCEPTED("승인"),
-    APPROVED("완료"),
+    CREATED,
+    ACCEPTED,
+    APPROVED,
     ;
 
-    private final String value;
-
-    ReviewStatus(final String value) {
-        this.value = value;
+    public static boolean isContain(final String name) {
+        return Arrays.stream(values())
+                .anyMatch(status -> status.name().equals(name));
     }
 }

--- a/src/main/java/project/reviewing/review/config/ReviewConfig.java
+++ b/src/main/java/project/reviewing/review/config/ReviewConfig.java
@@ -4,13 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import project.reviewing.review.presentation.ReviewRoleInterceptor;
+import project.reviewing.review.presentation.ReviewsByRoleParamInterceptor;
 
 @RequiredArgsConstructor
 @Configuration
 public class ReviewConfig implements WebMvcConfigurer {
 
-    private final ReviewRoleInterceptor reviewRoleInterceptor;
+    private final ReviewsByRoleParamInterceptor reviewRoleInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -39,7 +39,8 @@ public class ReviewController {
     @GetMapping("/reviews")
     public ReviewsResponse readReviewsByRole(
             @AuthenticatedMember final Long memberId,
-            @RequestParam(value = "role") final String role
+            @RequestParam final String role,
+            @RequestParam(required = false) final String status
     ) {
         return reviewQueryService.findReviewsByRole(memberId, RoleInReview.findValue(role));
     }

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import project.reviewing.auth.presentation.AuthenticatedMember;
 import project.reviewing.review.command.application.ReviewService;
 import project.reviewing.review.command.application.response.SingleReviewReadResponse;
+import project.reviewing.review.command.domain.ReviewStatus;
 import project.reviewing.review.presentation.data.RoleInReview;
 import project.reviewing.review.presentation.request.ReviewCreateRequest;
 import project.reviewing.review.presentation.request.ReviewUpdateRequest;
@@ -42,7 +43,7 @@ public class ReviewController {
             @RequestParam final String role,
             @RequestParam(required = false) final String status
     ) {
-        return reviewQueryService.findReviewsByRole(memberId, RoleInReview.findValue(role));
+        return reviewQueryService.findReviewsByRole(memberId, RoleInReview.findValue(role), ReviewStatus.of(status));
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/project/reviewing/review/presentation/ReviewsByRoleParamInterceptor.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewsByRoleParamInterceptor.java
@@ -4,19 +4,24 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import project.reviewing.common.exception.BadRequestException;
 import project.reviewing.common.exception.ErrorType;
+import project.reviewing.review.command.domain.ReviewStatus;
 import project.reviewing.review.presentation.data.RoleInReview;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
-public class ReviewRoleInterceptor implements HandlerInterceptor {
+public class ReviewsByRoleParamInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         final String role = request.getParameter("role");
+        final String status = request.getParameter("status");
 
-        if (role == null || !RoleInReview.isContain(role)) {
+        if (role != null && !RoleInReview.isContain(role)) {
+            throw new BadRequestException(ErrorType.QUERY_PARAM_INVALID_FORMAT);
+        }
+        if (status != null && !ReviewStatus.isContain(status)) {
             throw new BadRequestException(ErrorType.QUERY_PARAM_INVALID_FORMAT);
         }
         return true;

--- a/src/main/java/project/reviewing/review/query/application/ReviewQueryService.java
+++ b/src/main/java/project/reviewing/review/query/application/ReviewQueryService.java
@@ -3,6 +3,7 @@ package project.reviewing.review.query.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.reviewing.review.command.domain.ReviewStatus;
 import project.reviewing.review.presentation.data.RoleInReview;
 import project.reviewing.review.query.application.response.ReviewsResponse;
 import project.reviewing.review.query.dao.ReviewsDAO;
@@ -14,7 +15,7 @@ public class ReviewQueryService {
 
     private final ReviewsDAO reviewsDAO;
 
-    public ReviewsResponse findReviewsByRole(final Long memberId, final RoleInReview role) {
-        return ReviewsResponse.from(reviewsDAO.findReviewsByRole(memberId, role));
+    public ReviewsResponse findReviewsByRole(final Long memberId, final RoleInReview role, final ReviewStatus status) {
+        return ReviewsResponse.from(reviewsDAO.findReviewsByRole(memberId, role, status));
     }
 }

--- a/src/main/java/project/reviewing/review/query/dao/ReviewsDAO.java
+++ b/src/main/java/project/reviewing/review/query/dao/ReviewsDAO.java
@@ -19,10 +19,16 @@ public class ReviewsDAO {
     @PersistenceContext
     private final EntityManager em;
 
-    public List<ReviewByRoleData> findReviewsByRole(final Long memberId, final RoleInReview role) {
-        Query query = em.createQuery(makeJpqlByRole(memberId, role));
-        query.setParameter("memberId", memberId);
+    public List<ReviewByRoleData> findReviewsByRole(
+            final Long memberId, final RoleInReview role, final ReviewStatus status
+    ) {
+        final String jpql = makeJpqlByRole(memberId, role) + makeWhereClauseForStatus(status);
+        final Query query = em.createQuery(jpql)
+                .setParameter("memberId", memberId);
 
+        if (!status.isNone()) {
+            query.setParameter("status", status);
+        }
         return mapToReviewByRoleDataList(query.getResultList());
 
     }
@@ -42,6 +48,13 @@ public class ReviewsDAO {
                     + "JOIN Review rv ON rv.reviewerId = rr.id "
                     + "WHERE rv.revieweeId = :memberId";
         }
+    }
+
+    private String makeWhereClauseForStatus(final ReviewStatus status) {
+        if (status.isNone()) {
+            return "";
+        }
+        return " AND rv.status = :status";
     }
 
     private List<ReviewByRoleData> mapToReviewByRoleDataList(final List<Object[]> result) {

--- a/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
+++ b/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
@@ -241,9 +241,8 @@ public class ReviewServiceTest extends IntegrationTest {
             reviewService.acceptReview(reviewerMember.getId(), review.getId());
             entityManager.flush();
             entityManager.clear();
+
             reviewService.approveReview(reviewerMember.getId(), review.getId());
-            entityManager.flush();
-            entityManager.clear();
 
             final Review approvedReview = reviewRepository.findById(review.getId())
                     .orElseThrow(ReviewNotFoundException::new);


### PR DESCRIPTION
## 상세 내용

- 'status' Query Param 추가
   - 검증 Interceptor에 검증 로직 추가
- 요청 시 status 정보를 포함하지 않으면 모든 상태의 리뷰 목록 조회
- 요청 시 status 정보를 포함하면 해당 상태의 리뷰 목록 조회
- status 정보를 ReviewStatus Enum으로 관리하기 위해 status 정보가 없다는 의미로 NONE 상수 추가

## 주의 사항

<br/>

Close #23