### PR TITLE
[#42] Reviewer 목록 조회 시 정보가 중복되는 문제 해결

### DIFF
--- a/src/main/java/project/reviewing/member/query/dao/util/ReviewerDataMapper.java
+++ b/src/main/java/project/reviewing/member/query/dao/util/ReviewerDataMapper.java
@@ -1,9 +1,6 @@
 package project.reviewing.member.query.dao.util;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import project.reviewing.member.query.dao.data.ReviewerData;
 import project.reviewing.member.query.dao.data.ReviewerWithTagData;
@@ -14,7 +11,7 @@ public class ReviewerDataMapper {
     public static List<ReviewerData> map(final List<ReviewerWithTagData> reviewerWithTagData) {
         final Set<Long> reviewerIds = reviewerWithTagData.stream()
                 .map(ReviewerWithTagData::getId)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(TreeSet::new));
 
         final List<ReviewerData> reviewerData = new ArrayList<>();
 


### PR DESCRIPTION
## 상세 내용

- Reviewer 목록 조회 SQL 수정
- DTO Mapper 내에서 정렬되지 않는 HashSet 대신 TreeSet을 사용하여 Reviewer Id를 기준으로 정렬
- Reviewer 목록 연속된 페이지에 중복 데이터가 존재하는지 검증하기 위한 테스트 코드 추가

## 주의 사항

<br/>

Close #42