### PR TITLE
[#49] 리뷰어 목록 조회 시 500 에러 발생하는 문제 해결

### DIFF
--- a/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
+++ b/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
@@ -54,15 +54,18 @@ public class ReviewerDao {
                 + "JOIN tag t ON rt.tag_id = t.id "
                 + "WHERE r.id IN "
                 + "( "
-                + "SELECT DISTINCT r.id "
-                + "FROM reviewer r "
-                + "JOIN member m ON r.member_id = m.id "
-                + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
-                + "JOIN tag t ON rt.tag_id = t.id "
-                + "WHERE m.is_reviewer = true "
-                + makeWhereClause(categoryId, tagIds)
-                + "ORDER BY r.id "
-                + "LIMIT :limit OFFSET :offset "
+                + "SELECT DISTINCT subquery.sub_rid "
+                + "FROM ("
+                    + "SELECT DISTINCT r.id sub_rid "
+                    + "FROM reviewer r "
+                    + "JOIN member m ON r.member_id = m.id "
+                    + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
+                    + "JOIN tag t ON rt.tag_id = t.id "
+                    + "WHERE m.is_reviewer = true "
+                    + makeWhereClause(categoryId, tagIds)
+                    + "ORDER BY r.id "
+                    + "LIMIT :limit OFFSET :offset "
+                    + ") subquery"
                 + ")";
         final SqlParameterSource params = new MapSqlParameterSource("limit", pageable.getPageSize() + 1)
                 .addValue("offset", pageable.getOffset())


### PR DESCRIPTION
## 상세 내용

- MySQL과 MariaDB 간에 호환되지 않는 문법 수정
   - MariaDB에서는 Subquery에서 Limit을 지원하지 않아 Limit을 사용한 Subquery를 한 번 더 감싸 해결

## 주의 사항

<br/>

Close #49