### PR TITLE
[#52] 리뷰 거절 관련 세부적인 기능 추가

### DIFF
--- a/src/main/java/project/reviewing/review/command/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/command/application/ReviewService.java
@@ -61,6 +61,13 @@ public class ReviewService {
         review.accept(reviewerMember.getReviewer().getId(), time);
     }
 
+    public void refuseReview(final Long memberId, final Long reviewId) {
+        final Review review = findReviewById(reviewId);
+        final Member reviewerMember = findMemberById(memberId);
+
+        review.refuse(reviewerMember.getReviewer().getId(), time);
+    }
+
     public void approveReview(final Long memberId, final Long reviewId) {
         final Review review = findReviewById(reviewId);
         final Member reviewerMember = findMemberById(memberId);

--- a/src/main/java/project/reviewing/review/command/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/command/application/ReviewService.java
@@ -68,11 +68,11 @@ public class ReviewService {
         review.approve(reviewerMember.getReviewer().getId(), time);
     }
 
-    public void refuseReview(final Long memberId, final Long reviewId) {
+    public void finishReview(final Long memberId, final Long reviewId) {
         final Review review = findReviewById(reviewId);
         final Member reviewerMember = findMemberById(memberId);
 
-        if (review.canRefuse(reviewerMember.getReviewer().getId())) {
+        if (review.canFinish(reviewerMember.getReviewer().getId())) {
             reviewRepository.delete(review);
         }
     }

--- a/src/main/java/project/reviewing/review/command/application/response/SingleReviewReadResponse.java
+++ b/src/main/java/project/reviewing/review/command/application/response/SingleReviewReadResponse.java
@@ -19,7 +19,7 @@ public class SingleReviewReadResponse {
     public static SingleReviewReadResponse from(final Review review) {
         return new SingleReviewReadResponse(
                 review.getId(), review.getReviewerId(), review.getTitle(), review.getContent(), review.getPrUrl(),
-                review.getStatus().name(), review.getStatusSetAt().format(DateTimeFormatter.ofPattern("YYYY-MM-dd HH시"))
+                review.getStatus().name(), review.getStatusSetAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH시"))
         );
     }
 

--- a/src/main/java/project/reviewing/review/command/application/response/SingleReviewReadResponse.java
+++ b/src/main/java/project/reviewing/review/command/application/response/SingleReviewReadResponse.java
@@ -3,6 +3,8 @@ package project.reviewing.review.command.application.response;
 import lombok.Getter;
 import project.reviewing.review.command.domain.Review;
 
+import java.time.format.DateTimeFormatter;
+
 @Getter
 public class SingleReviewReadResponse {
 
@@ -12,17 +14,18 @@ public class SingleReviewReadResponse {
     private final String content;
     private final String prUrl;
     private final String status;
+    private final String statusSetAt;
 
     public static SingleReviewReadResponse from(final Review review) {
         return new SingleReviewReadResponse(
-                review.getId(), review.getReviewerId(), review.getTitle(),
-                review.getContent(), review.getPrUrl(), review.getStatus().name()
+                review.getId(), review.getReviewerId(), review.getTitle(), review.getContent(), review.getPrUrl(),
+                review.getStatus().name(), review.getStatusSetAt().format(DateTimeFormatter.ofPattern("YYYY-MM-dd HH시"))
         );
     }
 
     private SingleReviewReadResponse(
-            final Long id, final Long reviewerId, final String title,
-            final String content, final String prUrl, final String status
+            final Long id, final Long reviewerId, final String title, final String content,
+            final String prUrl, final String status, final String statusSetAt
     ) {
         this.id = id;
         this.reviewerId = reviewerId;
@@ -30,5 +33,6 @@ public class SingleReviewReadResponse {
         this.content = content;
         this.prUrl = prUrl;
         this.status = status;
+        this.statusSetAt = statusSetAt;
     }
 }

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -76,9 +76,11 @@ public class Review {
         statusSetAt = time.now();
     }
 
-    public boolean canRefuse(final Long reviewerId) {
+    public boolean canFinish(final Long reviewerId) {
         checkReviewer(reviewerId);
-        checkStatusCreated();
+        if (status != ReviewStatus.REFUSED) {
+            throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
+        }
         return true;
     }
 

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -91,6 +91,12 @@ public class Review {
         return true;
     }
 
+    public boolean isExpiredInRefusedStatus() {
+        return (status == ReviewStatus.REFUSED) &&
+                (statusSetAt.plusDays(3).isBefore(LocalDateTime.now()) ||
+                        (statusSetAt.plusDays(3).isEqual(LocalDateTime.now())));
+    }
+
     public boolean isExpiredInApprovedStatus() {
         return (status == ReviewStatus.APPROVED) &&
                 (statusSetAt.plusDays(3).isBefore(LocalDateTime.now()) ||

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -69,6 +69,13 @@ public class Review {
         statusSetAt = time.now();
     }
 
+    public void refuse(final Long reviewerId, Time time) {
+        checkReviewer(reviewerId);
+        checkStatusCreated();
+        status = ReviewStatus.REFUSED;
+        statusSetAt = time.now();
+    }
+
     public void approve(final Long reviewerId, Time time) {
         checkReviewer(reviewerId);
         checkStatusAccepted();

--- a/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
@@ -7,6 +7,7 @@ public enum ReviewStatus {
     NONE,
     CREATED,
     ACCEPTED,
+    REFUSED,
     APPROVED,
     ;
 

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -76,10 +76,10 @@ public class ReviewController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/reviewers/{reviewer-id}/reviews/{review-id}")
-    public void refuseReview(
+    public void finishReview(
             @AuthenticatedMember final Long memberId,
             @PathVariable("review-id") final Long reviewId
     ) {
-        reviewService.refuseReview(memberId, reviewId);
+        reviewService.finishReview(memberId, reviewId);
     }
 }

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -71,6 +71,7 @@ public class ReviewController {
             @AuthenticatedMember final Long memberId,
             @PathVariable("review-id") final Long reviewId
     ) {
+        reviewService.refuseReview(memberId, reviewId);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -66,6 +66,14 @@ public class ReviewController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/reviewers/{reviewer-id}/reviews/{review-id}/status-refused")
+    public void refuseReview(
+            @AuthenticatedMember final Long memberId,
+            @PathVariable("review-id") final Long reviewId
+    ) {
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PatchMapping("/reviewers/{reviewer-id}/reviews/{review-id}/status-approved")
     public void approveReview(
             @AuthenticatedMember final Long memberId,

--- a/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
@@ -21,7 +21,7 @@ public class ReviewScheduler {
         final List<Review> reviews = reviewRepository.findAll();
 
         for (Review review : reviews) {
-            if (review.isExpiredInApprovedStatus()) {
+            if (review.isExpiredInRefusedStatus() || review.isExpiredInApprovedStatus()) {
                 reviewRepository.delete(review);
             }
         }

--- a/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
+++ b/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
@@ -247,6 +247,66 @@ public class ReviewServiceTest extends IntegrationTest {
         }
     }
 
+    @DisplayName("리뷰 거절 시")
+    @Nested
+    class ReviewRefuseTest {
+
+        @DisplayName("정상적으로 거절된다.")
+        @Test
+        void validRefuseReview() {
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+
+            reviewService.refuseReview(reviewerMember.getId(), review.getId());
+            entityManager.flush();
+            entityManager.clear();
+
+            final Review refusedReview = reviewRepository.findById(review.getId())
+                    .orElseThrow(ReviewNotFoundException::new);
+            assertThat(refusedReview.getStatus()).isEqualTo(ReviewStatus.REFUSED);
+        }
+
+        @DisplayName("리뷰 정보가 없으면 예외 발생한다.")
+        @Test
+        void refuseWithNotExistReview() {
+            final Long invalidReviewId = -1L;
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+
+            assertThatThrownBy(() -> reviewService.refuseReview(reviewerMember.getId(), invalidReviewId))
+                    .isInstanceOf(ReviewNotFoundException.class);
+        }
+
+        @DisplayName("요청한 회원 정보가 없으면 예외 발생한다.")
+        @Test
+        void refuseWithNotExistMember() {
+            final Long invalidMemberId = -1L;
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+
+            assertThatThrownBy(() -> reviewService.refuseReview(invalidMemberId, review.getId()))
+                    .isInstanceOf(MemberNotFoundException.class);
+        }
+    }
+
     @DisplayName("리뷰 완료 시")
     @Nested
     class ReviewApproveTest {

--- a/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
+++ b/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
@@ -309,13 +309,13 @@ public class ReviewServiceTest extends IntegrationTest {
         }
     }
 
-    @DisplayName("리뷰 거절 시")
+    @DisplayName("리뷰 종료 시")
     @Nested
-    class ReviewRefuseTest {
+    class ReviewFinishTest {
 
-        @DisplayName("정상적으로 거절된다.")
+        @DisplayName("정상적으로 종료된다.")
         @Test
-        void validRefuseReview() {
+        void validFinishReview() {
             final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
             final Member reviewerMember = createMemberAndRegisterReviewer(
                     new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
@@ -328,6 +328,9 @@ public class ReviewServiceTest extends IntegrationTest {
                     ));
 
             reviewService.refuseReview(reviewerMember.getId(), review.getId());
+            entityManager.flush();
+            entityManager.clear();
+            reviewService.finishReview(reviewerMember.getId(), review.getId());
             entityManager.flush();
             entityManager.clear();
 
@@ -343,7 +346,7 @@ public class ReviewServiceTest extends IntegrationTest {
                     new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
             );
 
-            assertThatThrownBy(() -> reviewService.refuseReview(reviewerMember.getId(), invalidReviewId))
+            assertThatThrownBy(() -> reviewService.finishReview(reviewerMember.getId(), invalidReviewId))
                     .isInstanceOf(ReviewNotFoundException.class);
         }
 
@@ -362,7 +365,7 @@ public class ReviewServiceTest extends IntegrationTest {
                             "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
                     ));
 
-            assertThatThrownBy(() -> reviewService.refuseReview(invalidMemberId, review.getId()))
+            assertThatThrownBy(() -> reviewService.finishReview(invalidMemberId, review.getId()))
                     .isInstanceOf(MemberNotFoundException.class);
         }
     }

--- a/src/test/java/project/reviewing/integration/review/scheduler/ReviewSchedulerTest.java
+++ b/src/test/java/project/reviewing/integration/review/scheduler/ReviewSchedulerTest.java
@@ -57,4 +57,25 @@ public class ReviewSchedulerTest extends IntegrationTest {
         // then
         assertThat(reviewRepository.findAll()).hasSize(2);
     }
+
+    @DisplayName("거절 된 리뷰 중 일정 기간이 지나면 삭제할 수 있다.")
+    @Test
+    void deleteExpiredRefusedReviews() {
+        // given
+        when(time.now()).thenReturn(LocalDateTime.now().minusDays(4));
+
+        final Review review = createReview(Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time));
+        createReview(Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time));
+
+        review.refuse(1L, time);
+        entityManager.merge(review);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        reviewScheduler.checkExpirationForAllReview();
+
+        // then
+        assertThat(reviewRepository.findAll()).hasSize(1);
+    }
 }

--- a/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
+++ b/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
@@ -135,32 +135,32 @@ public class ReviewTest {
                 .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
     }
 
-    @DisplayName("리뷰를 거절할 수 있는지 조건을 확인할 수 있다.")
+    @DisplayName("리뷰를 종료할 수 있는지 조건을 확인할 수 있다.")
     @Test
     void validRefuseReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
-        assertThat(review.canRefuse(1L)).isTrue();
+        review.refuse(1L, time);
+
+        assertThat(review.canFinish(1L)).isTrue();
     }
 
-    @DisplayName("리뷰를 요청받은 리뷰어가 아니면 거절할 수 없다.")
+    @DisplayName("리뷰를 요청받은 리뷰어가 아니면 종료할 수 없다.")
     @Test
     void refuseWithNotReviewerOfReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
-        assertThatThrownBy(() -> review.canRefuse(2L))
+        assertThatThrownBy(() -> review.canFinish(2L))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
     }
 
-    @DisplayName("리뷰의 상태가 CREATED(생성) 상태가 아니면 거절할 수 없다.")
+    @DisplayName("리뷰의 상태가 REFUSED(거절) 상태가 아니면 종료할 수 없다.")
     @Test
     void refuseWithNotProperStatus() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
-        review.accept(1L, time); // Accepted 상태로 변경
-
-        assertThatThrownBy(() -> review.canRefuse(1L))
+        assertThatThrownBy(() -> review.canFinish(1L))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
     }

--- a/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
+++ b/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
@@ -102,6 +102,38 @@ public class ReviewTest {
                 .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
     }
 
+    @DisplayName("리뷰를 거절할 수 있다.")
+    @Test
+    void validRefuseReview() {
+        final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
+
+        review.refuse(1L, time);
+
+        assertThat(review.getStatus()).isEqualTo(ReviewStatus.REFUSED);
+    }
+
+    @DisplayName("리뷰를 요청받은 리뷰어가 아니면 거절할 수 없다.")
+    @Test
+    void refuseWithNotReviewerOfReview() {
+        final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
+
+        assertThatThrownBy(() -> review.refuse(2L, time))
+                .isInstanceOf(InvalidReviewException.class)
+                .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
+    }
+
+    @DisplayName("리뷰의 상태가 CREATED(생성) 상태가 아니면 거절할 수 없다.")
+    @Test
+    void refuseWithNotProperStatus() {
+        final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
+
+        review.accept(1L, time);
+
+        assertThatThrownBy(() -> review.refuse(1L, time))
+                .isInstanceOf(InvalidReviewException.class)
+                .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
+    }
+
     @DisplayName("리뷰를 완료할 수 있다.")
     @Test
     void validApproveReview() {
@@ -137,7 +169,7 @@ public class ReviewTest {
 
     @DisplayName("리뷰를 종료할 수 있는지 조건을 확인할 수 있다.")
     @Test
-    void validRefuseReview() {
+    void validFinishReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
         review.refuse(1L, time);
@@ -147,7 +179,7 @@ public class ReviewTest {
 
     @DisplayName("리뷰를 요청받은 리뷰어가 아니면 종료할 수 없다.")
     @Test
-    void refuseWithNotReviewerOfReview() {
+    void finishWithNotReviewerOfReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
         assertThatThrownBy(() -> review.canFinish(2L))
@@ -157,7 +189,7 @@ public class ReviewTest {
 
     @DisplayName("리뷰의 상태가 REFUSED(거절) 상태가 아니면 종료할 수 없다.")
     @Test
-    void refuseWithNotProperStatus() {
+    void finishWithNotProperStatus() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
         assertThatThrownBy(() -> review.canFinish(1L))

--- a/src/test/java/project/reviewing/unit/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/project/reviewing/unit/review/presentation/ReviewControllerTest.java
@@ -278,7 +278,7 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("요청이 유효하면 204 반환한다.")
         @Test
         void validAcceptReview() throws Exception {
-            requestAboutReview(delete("/reviewers/1/reviews/1"), null)
+            requestAboutReview(patch("/reviewers/1/reviews/1/status-refused"), null)
                     .andExpect(status().isNoContent());
         }
     }
@@ -291,6 +291,18 @@ public class ReviewControllerTest extends ControllerTest {
         @Test
         void validAcceptReview() throws Exception {
             requestAboutReview(patch("/reviewers/1/reviews/1/status-approved"), null)
+                    .andExpect(status().isNoContent());
+        }
+    }
+
+    @DisplayName("리뷰 종료 시")
+    @Nested
+    class ReviewFinishTest {
+
+        @DisplayName("요청이 유효하면 204 반환한다.")
+        @Test
+        void validAcceptReview() throws Exception {
+            requestAboutReview(delete("/reviewers/1/reviews/1"), null)
                     .andExpect(status().isNoContent());
         }
     }


### PR DESCRIPTION
## 상세 내용

- 리뷰 거절 상태 'REFUSED' 추가
- 기존의 리뷰 거절 API 로직을 종료 API로 변경
- 새 리뷰 거절 API 로직 추가
- Scheduler에 거절 된 리뷰 중 일정 기간이 지났을 때 삭제하는 로직 추가
- 단일 리뷰 상세 정보 조회 API 응답에 '리뷰 상태 설정 시간' 정보 추가
- 테스트 코드 추가

## 주의 사항

<br/>

Close #52