### PR TITLE
[#52] 리뷰 상세 정보 조회 응답 데이터 '상태 변경 날짜' -> '만료 날짜'로 변경

### DIFF
--- a/src/main/java/project/reviewing/review/command/application/response/SingleReviewReadResponse.java
+++ b/src/main/java/project/reviewing/review/command/application/response/SingleReviewReadResponse.java
@@ -14,18 +14,18 @@ public class SingleReviewReadResponse {
     private final String content;
     private final String prUrl;
     private final String status;
-    private final String statusSetAt;
+    private final String expireDate;
 
     public static SingleReviewReadResponse from(final Review review) {
         return new SingleReviewReadResponse(
                 review.getId(), review.getReviewerId(), review.getTitle(), review.getContent(), review.getPrUrl(),
-                review.getStatus().name(), review.getStatusSetAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH시"))
+                review.getStatus().name(), review.findExpireDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH시"))
         );
     }
 
     private SingleReviewReadResponse(
             final Long id, final Long reviewerId, final String title, final String content,
-            final String prUrl, final String status, final String statusSetAt
+            final String prUrl, final String status, final String expireDate
     ) {
         this.id = id;
         this.reviewerId = reviewerId;
@@ -33,6 +33,6 @@ public class SingleReviewReadResponse {
         this.content = content;
         this.prUrl = prUrl;
         this.status = status;
-        this.statusSetAt = statusSetAt;
+        this.expireDate = expireDate;
     }
 }

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -102,19 +102,23 @@ public class Review {
     }
 
     public boolean isExpiredInCreatedStatus() {
-        return (status == ReviewStatus.CREATED) && isExpiredInDays(3);
+        return (status == ReviewStatus.CREATED) && isExpired();
     }
 
     public boolean isExpiredInAcceptedStatus() {
-        return (status == ReviewStatus.ACCEPTED) && isExpiredInDays(3);
+        return (status == ReviewStatus.ACCEPTED) && isExpired();
     }
 
     public boolean isExpiredInRefusedStatus() {
-        return (status == ReviewStatus.REFUSED) && isExpiredInDays(3);
+        return (status == ReviewStatus.REFUSED) && isExpired();
     }
 
     public boolean isExpiredInApprovedStatus() {
-        return (status == ReviewStatus.APPROVED) && isExpiredInDays(3);
+        return (status == ReviewStatus.APPROVED) && isExpired();
+    }
+
+    public LocalDateTime findExpireDate() {
+        return statusSetAt.plusDays(3);
     }
 
     private void checkReviewer(final Long reviewerId) {
@@ -141,9 +145,9 @@ public class Review {
         }
     }
 
-    private boolean isExpiredInDays(final int days) {
-        return statusSetAt.plusDays(3).isBefore(LocalDateTime.now())
-                || statusSetAt.plusDays(3).isEqual(LocalDateTime.now());
+    private boolean isExpired() {
+        LocalDateTime expireDate = findExpireDate();
+        return expireDate.isBefore(LocalDateTime.now()) || expireDate.isEqual(LocalDateTime.now());
     }
 
     private Review(


### PR DESCRIPTION
## 상세 내용

- Review의 만료 시간을 구하는 로직 Method로 추출
- 리뷰 상세 정보 조회의 응답 데이터에서 리뷰의 '상태 변경 날짜' -> '만료 날짜'로 변경

## 주의 사항

<br/>

Close #52