### PR TITLE
[#69] 리뷰 평가 작성 기능 구현

### DIFF
--- a/src/main/java/project/reviewing/common/exception/ErrorType.java
+++ b/src/main/java/project/reviewing/common/exception/ErrorType.java
@@ -31,6 +31,8 @@ public enum ErrorType {
     NOT_REVIEWER_OF_REVIEW("REVIEW-005", "해당 리뷰의 리뷰어가 아닙니다."),
     NOT_PROPER_REVIEW_STATUS("REVIEW-006", "리뷰의 상태가 적절하지 않습니다."),
     ROLE_IN_REVIEW_NOT_FOUND("REVIEW-007", "해당 리뷰의 역할을 찾을 수 없습니다."),
+
+    ALREADY_EVALUATED("EVALUATION-001", "이미 해당 리뷰에 대한 평가가 되었습니다.")
     ;
 
     private final String code;

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -44,6 +44,8 @@ public class EvaluationService {
             throw new InvalidEvaluationException(ErrorType.NOT_REVIEWER_OF_REVIEW);
         }
 
+        reviewerMember.updateReviewerScore(evaluationCreateRequest.getScore());
+
         Evaluation evaluation = evaluationCreateRequest.toEntity(reviewerId, memberId);
         evaluationRepository.save(evaluation);
     }

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -40,9 +40,6 @@ public class EvaluationService {
         if (!memberId.equals(review.getRevieweeId())) {
             throw new InvalidEvaluationException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
         }
-        if (reviewerMember.isNotRegisterReviewer()) {
-            throw new InvalidEvaluationException(ErrorType.REVIEWER_NOT_FOUND);
-        }
         if (!reviewerMember.getReviewer().getId().equals(review.getReviewerId())) {
             throw new InvalidEvaluationException(ErrorType.NOT_REVIEWER_OF_REVIEW);
         }

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -40,6 +40,9 @@ public class EvaluationService {
         if (!memberId.equals(review.getRevieweeId())) {
             throw new InvalidEvaluationException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
         }
+        if (reviewerMember.isNotRegisterReviewer()) {
+            throw new InvalidEvaluationException(ErrorType.REVIEWER_NOT_FOUND);
+        }
         if (!reviewerMember.getReviewer().getId().equals(review.getReviewerId())) {
             throw new InvalidEvaluationException(ErrorType.NOT_REVIEWER_OF_REVIEW);
         }

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -1,0 +1,50 @@
+package project.reviewing.evaluation.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.reviewing.common.exception.ErrorType;
+import project.reviewing.evaluation.domain.Evaluation;
+import project.reviewing.evaluation.domain.EvaluationRepository;
+import project.reviewing.evaluation.exception.InvalidEvaluationException;
+import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
+import project.reviewing.member.command.domain.Member;
+import project.reviewing.member.command.domain.MemberRepository;
+import project.reviewing.member.exception.MemberNotFoundException;
+import project.reviewing.review.command.domain.Review;
+import project.reviewing.review.command.domain.ReviewRepository;
+import project.reviewing.review.exception.ReviewNotFoundException;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class EvaluationService {
+
+    private final MemberRepository memberRepository;
+    private final ReviewRepository reviewRepository;
+    private final EvaluationRepository evaluationRepository;
+
+    public void createEvaluation(
+            final Long memberId,
+            final Long reviewerId,
+            final EvaluationCreateRequest evaluationCreateRequest
+    ) {
+        final Member reviewerMember = memberRepository.findByReviewerId(reviewerId)
+                .orElseThrow(MemberNotFoundException::new);
+        final Review review = reviewRepository.findById(evaluationCreateRequest.getReviewId())
+                .orElseThrow(ReviewNotFoundException::new);
+
+        if (evaluationRepository.existsByReviewId(evaluationCreateRequest.getReviewId())) {
+            throw new InvalidEvaluationException(ErrorType.ALREADY_EVALUATED);
+        }
+        if (!memberId.equals(review.getRevieweeId())) {
+            throw new InvalidEvaluationException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
+        }
+        if (!reviewerMember.getReviewer().getId().equals(review.getReviewerId())) {
+            throw new InvalidEvaluationException(ErrorType.NOT_REVIEWER_OF_REVIEW);
+        }
+
+        Evaluation evaluation = evaluationCreateRequest.toEntity(reviewerId, memberId);
+        evaluationRepository.save(evaluation);
+    }
+}

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -37,16 +37,13 @@ public class EvaluationService {
         if (evaluationRepository.existsByReviewId(evaluationCreateRequest.getReviewId())) {
             throw new InvalidEvaluationException(ErrorType.ALREADY_EVALUATED);
         }
-        if (!memberId.equals(review.getRevieweeId())) {
-            throw new InvalidEvaluationException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
-        }
-        if (!reviewerMember.getReviewer().getId().equals(review.getReviewerId())) {
-            throw new InvalidEvaluationException(ErrorType.NOT_REVIEWER_OF_REVIEW);
-        }
 
-        reviewerMember.updateReviewerScore(evaluationCreateRequest.getScore());
+        if (review.canEvaluate(memberId, reviewerId)) {
+            review.evaluate();
+            reviewerMember.updateReviewerScore(evaluationCreateRequest.getScore());
 
-        Evaluation evaluation = evaluationCreateRequest.toEntity(reviewerId, memberId);
-        evaluationRepository.save(evaluation);
+            Evaluation evaluation = evaluationCreateRequest.toEntity(reviewerId, memberId);
+            evaluationRepository.save(evaluation);
+        }
     }
 }

--- a/src/main/java/project/reviewing/evaluation/domain/Evaluation.java
+++ b/src/main/java/project/reviewing/evaluation/domain/Evaluation.java
@@ -1,0 +1,30 @@
+package project.reviewing.evaluation.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Evaluation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long reviewId;
+
+    @Column(nullable = false)
+    private Long revieweeId;
+
+    @Column(nullable = false)
+    private Long reviewerId;
+
+    @Column(nullable = false)
+    private Float score;
+
+    @Column(nullable = false, length = 100)
+    private String content;
+}

--- a/src/main/java/project/reviewing/evaluation/domain/Evaluation.java
+++ b/src/main/java/project/reviewing/evaluation/domain/Evaluation.java
@@ -13,18 +13,28 @@ public class Evaluation {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
-    private Long reviewId;
+    @Column(nullable = false)
+    private Long reviewerId;
 
     @Column(nullable = false)
     private Long revieweeId;
 
-    @Column(nullable = false)
-    private Long reviewerId;
+    @Column(nullable = false, unique = true)
+    private Long reviewId;
 
     @Column(nullable = false)
     private Float score;
 
     @Column(nullable = false, length = 100)
     private String content;
+
+    public Evaluation(
+            final Long reviewId, final Long revieweeId, final Long reviewerId, final Float score, final String content
+    ) {
+        this.reviewId = reviewId;
+        this.revieweeId = revieweeId;
+        this.reviewerId = reviewerId;
+        this.score = score;
+        this.content = content;
+    }
 }

--- a/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
+++ b/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
@@ -1,0 +1,8 @@
+package project.reviewing.evaluation.domain;
+
+import org.springframework.data.repository.Repository;
+
+public interface EvaluationRepository extends Repository<Evaluation, Long> {
+
+    void save(Evaluation entity);
+}

--- a/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
+++ b/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
@@ -2,8 +2,11 @@ package project.reviewing.evaluation.domain;
 
 import org.springframework.data.repository.Repository;
 
+import java.util.Optional;
+
 public interface EvaluationRepository extends Repository<Evaluation, Long> {
 
     boolean existsByReviewId(Long reviewId);
-    void save(Evaluation entity);
+    Evaluation save(Evaluation entity);
+    Optional<Evaluation> findById(Long id);
 }

--- a/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
+++ b/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
@@ -4,5 +4,6 @@ import org.springframework.data.repository.Repository;
 
 public interface EvaluationRepository extends Repository<Evaluation, Long> {
 
+    boolean existsByReviewId(Long reviewId);
     void save(Evaluation entity);
 }

--- a/src/main/java/project/reviewing/evaluation/exception/InvalidEvaluationException.java
+++ b/src/main/java/project/reviewing/evaluation/exception/InvalidEvaluationException.java
@@ -1,0 +1,11 @@
+package project.reviewing.evaluation.exception;
+
+import project.reviewing.common.exception.BadRequestException;
+import project.reviewing.common.exception.ErrorType;
+
+public class InvalidEvaluationException extends BadRequestException {
+
+    public InvalidEvaluationException(final ErrorType errorType) {
+        super(errorType);
+    }
+}

--- a/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
@@ -1,0 +1,23 @@
+package project.reviewing.evaluation.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import project.reviewing.auth.presentation.AuthenticatedMember;
+import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
+
+@RequiredArgsConstructor
+@RestController
+public class EvaluationController {
+
+    @PostMapping("/reviewers/{reviewer-id}/evaluations")
+    public void createEvaluation(
+            @AuthenticatedMember final Long memberId,
+            @PathVariable("reviewer-id") final Long reviewerId,
+            @RequestBody final EvaluationCreateRequest evaluationCreateRequest
+    ) {
+
+    }
+}

--- a/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import project.reviewing.auth.presentation.AuthenticatedMember;
+import project.reviewing.evaluation.application.EvaluationService;
 import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
 
 import javax.validation.Valid;
@@ -14,12 +15,14 @@ import javax.validation.Valid;
 @RestController
 public class EvaluationController {
 
+    private final EvaluationService evaluationService;
+
     @PostMapping("/reviewers/{reviewer-id}/evaluations")
     public void createEvaluation(
             @AuthenticatedMember final Long memberId,
             @PathVariable("reviewer-id") final Long reviewerId,
             @Valid @RequestBody final EvaluationCreateRequest evaluationCreateRequest
     ) {
-
+        evaluationService.createEvaluation(memberId, reviewerId, evaluationCreateRequest);
     }
 }

--- a/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 import project.reviewing.auth.presentation.AuthenticatedMember;
 import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
 
+import javax.validation.Valid;
+
 @RequiredArgsConstructor
 @RestController
 public class EvaluationController {
@@ -16,7 +18,7 @@ public class EvaluationController {
     public void createEvaluation(
             @AuthenticatedMember final Long memberId,
             @PathVariable("reviewer-id") final Long reviewerId,
-            @RequestBody final EvaluationCreateRequest evaluationCreateRequest
+            @Valid @RequestBody final EvaluationCreateRequest evaluationCreateRequest
     ) {
 
     }

--- a/src/main/java/project/reviewing/evaluation/presentation/request/EvaluationCreateRequest.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/request/EvaluationCreateRequest.java
@@ -1,0 +1,17 @@
+package project.reviewing.evaluation.presentation.request;
+
+import lombok.Getter;
+
+@Getter
+public class EvaluationCreateRequest {
+
+    private final Long reviewId;
+    private final Float score;
+    private final String content;
+
+    public EvaluationCreateRequest(final Long reviewId, final Float score, final String content) {
+        this.reviewId = reviewId;
+        this.score = score;
+        this.content = content;
+    }
+}

--- a/src/main/java/project/reviewing/evaluation/presentation/request/EvaluationCreateRequest.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/request/EvaluationCreateRequest.java
@@ -2,11 +2,20 @@ package project.reviewing.evaluation.presentation.request;
 
 import lombok.Getter;
 
+import javax.validation.constraints.*;
+
 @Getter
 public class EvaluationCreateRequest {
 
+    @NotNull
     private final Long reviewId;
+
+    @Min(0) @Max(5)
+    @NotNull
     private final Float score;
+
+    @Size(min = 1, max = 100, message = "본문은 100자 이하로 작성해 주세요.")
+    @NotBlank(message = "본문을 입력해 주세요.")
     private final String content;
 
     public EvaluationCreateRequest(final Long reviewId, final Float score, final String content) {

--- a/src/main/java/project/reviewing/evaluation/presentation/request/EvaluationCreateRequest.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/request/EvaluationCreateRequest.java
@@ -1,6 +1,7 @@
 package project.reviewing.evaluation.presentation.request;
 
 import lombok.Getter;
+import project.reviewing.evaluation.domain.Evaluation;
 
 import javax.validation.constraints.*;
 
@@ -22,5 +23,9 @@ public class EvaluationCreateRequest {
         this.reviewId = reviewId;
         this.score = score;
         this.content = content;
+    }
+
+    public Evaluation toEntity(final Long reviewerId, final Long revieweeId) {
+        return new Evaluation(reviewerId, revieweeId, reviewId, score, content);
     }
 }

--- a/src/main/java/project/reviewing/member/command/domain/Member.java
+++ b/src/main/java/project/reviewing/member/command/domain/Member.java
@@ -80,4 +80,8 @@ public class Member {
         }
         this.isReviewer = !isReviewer;
     }
+
+    public void updateReviewerScore(final Float evaluationScore) {
+        reviewer.updateScore(evaluationScore);
+    }
 }

--- a/src/main/java/project/reviewing/member/command/domain/Member.java
+++ b/src/main/java/project/reviewing/member/command/domain/Member.java
@@ -84,8 +84,4 @@ public class Member {
     public void updateReviewerScore(final Float evaluationScore) {
         reviewer.updateScore(evaluationScore);
     }
-
-    public boolean isNotRegisterReviewer() {
-        return reviewer == null;
-    }
 }

--- a/src/main/java/project/reviewing/member/command/domain/Member.java
+++ b/src/main/java/project/reviewing/member/command/domain/Member.java
@@ -84,4 +84,8 @@ public class Member {
     public void updateReviewerScore(final Float evaluationScore) {
         reviewer.updateScore(evaluationScore);
     }
+
+    public boolean isNotRegisterReviewer() {
+        return reviewer == null;
+    }
 }

--- a/src/main/java/project/reviewing/member/command/domain/Reviewer.java
+++ b/src/main/java/project/reviewing/member/command/domain/Reviewer.java
@@ -68,4 +68,11 @@ public class Reviewer {
         this.techStack = reviewer.getTechStack();
         this.introduction = reviewer.getIntroduction();
     }
+
+    void updateScore(final Float evaluationScore) {
+        float totalScore = score * evaluationCnt + evaluationScore;
+
+        score = Math.round((totalScore / (evaluationCnt + 1)) * 100) / 100.0F;
+        evaluationCnt++;
+    }
 }

--- a/src/main/java/project/reviewing/member/command/domain/Reviewer.java
+++ b/src/main/java/project/reviewing/member/command/domain/Reviewer.java
@@ -39,6 +39,12 @@ public class Reviewer {
 
     private String introduction;
 
+    @Column(nullable = false)
+    private Float score;
+
+    @Column(nullable = false)
+    private Long evaluationCnt;
+
     @OneToOne
     @JoinColumn(name = "member_id")
     private Member member;
@@ -48,6 +54,8 @@ public class Reviewer {
         this.career = career;
         this.techStack = techStack;
         this.introduction = introduction;
+        score = 0.0F;
+        evaluationCnt = 0L;
     }
 
     public void addMember(final Member member) {

--- a/src/main/java/project/reviewing/review/command/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/command/application/ReviewService.java
@@ -81,11 +81,11 @@ public class ReviewService {
         }
     }
 
-    public void finishReview(final Long memberId, final Long reviewId) {
+    public void closeReview(final Long memberId, final Long reviewId) {
         final Review review = findReviewById(reviewId);
         final Member reviewerMember = findMemberById(memberId);
 
-        if (review.canFinish(reviewerMember.getReviewer().getId())) {
+        if (review.canClose(reviewerMember.getReviewer().getId())) {
             reviewRepository.delete(review);
         }
     }

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -56,9 +56,7 @@ public class Review {
     }
 
     public void update(final Long revieweeId, final String updatingContent) {
-        if (!this.revieweeId.equals(revieweeId)) {
-            throw new InvalidReviewException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
-        }
+        checkReviewee(revieweeId);
         content = updatingContent;
     }
 
@@ -75,6 +73,10 @@ public class Review {
     public void approve(Time time) {
         status = ReviewStatus.APPROVED;
         statusSetAt = time.now();
+    }
+
+    public void evaluate() {
+        status = ReviewStatus.EVALUATED;
     }
 
     public boolean canAccept(final Long reviewerId) {
@@ -101,6 +103,13 @@ public class Review {
         return true;
     }
 
+    public boolean canEvaluate(final Long revieweeId, final long reviewerId) {
+        checkReviewee(revieweeId);
+        checkReviewer(reviewerId);
+        checkStatusApproved();
+        return true;
+    }
+
     public boolean isExpiredInCreatedStatus() {
         return (status == ReviewStatus.CREATED) && isExpired();
     }
@@ -121,9 +130,15 @@ public class Review {
         return statusSetAt.plusDays(3);
     }
 
-    private void checkReviewer(final Long reviewerId) {
+    public void checkReviewer(final Long reviewerId) {
         if (!this.reviewerId.equals(reviewerId)) {
             throw new InvalidReviewException(ErrorType.NOT_REVIEWER_OF_REVIEW);
+        }
+    }
+
+    public void checkReviewee(final Long revieweeId) {
+        if (!this.revieweeId.equals(revieweeId)) {
+            throw new InvalidReviewException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
         }
     }
 
@@ -141,6 +156,12 @@ public class Review {
 
     private void checkStatusRefused() {
         if (status != ReviewStatus.REFUSED) {
+            throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
+        }
+    }
+
+    private void checkStatusApproved() {
+        if (status != ReviewStatus.APPROVED) {
             throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
         }
     }

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -97,7 +97,7 @@ public class Review {
         return true;
     }
 
-    public boolean canFinish(final Long reviewerId) {
+    public boolean canClose(final Long reviewerId) {
         checkReviewer(reviewerId);
         checkStatusRefused();
         return true;

--- a/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
@@ -9,6 +9,7 @@ public enum ReviewStatus {
     ACCEPTED,
     REFUSED,
     APPROVED,
+    EVALUATED
     ;
 
     public static boolean isContain(final String name) {

--- a/src/main/java/project/reviewing/review/presentation/ReviewController.java
+++ b/src/main/java/project/reviewing/review/presentation/ReviewController.java
@@ -85,10 +85,10 @@ public class ReviewController {
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @DeleteMapping("/reviewers/{reviewer-id}/reviews/{review-id}")
-    public void finishReview(
+    public void closeReview(
             @AuthenticatedMember final Long memberId,
             @PathVariable("review-id") final Long reviewId
     ) {
-        reviewService.finishReview(memberId, reviewId);
+        reviewService.closeReview(memberId, reviewId);
     }
 }

--- a/src/main/java/project/reviewing/review/query/dao/ReviewsDAO.java
+++ b/src/main/java/project/reviewing/review/query/dao/ReviewsDAO.java
@@ -54,6 +54,9 @@ public class ReviewsDAO {
         if (status.isNone()) {
             return "";
         }
+        if (status == ReviewStatus.APPROVED) {
+            return " AND (rv.status = :status OR rv.status = '" + ReviewStatus.EVALUATED.name() + "')";
+        }
         return " AND rv.status = :status";
     }
 

--- a/src/main/resources/db/migration/V1_3__drop_foreign_key_constraint_in_review.sql
+++ b/src/main/resources/db/migration/V1_3__drop_foreign_key_constraint_in_review.sql
@@ -1,0 +1,5 @@
+ALTER TABLE review DROP FOREIGN KEY review_ibfk_1;
+ALTER TABLE review DROP FOREIGN KEY review_ibfk_2;
+
+ALTER TABLE review DROP INDEX reviewee_id;
+ALTER TABLE review DROP INDEX reviewer_id;

--- a/src/main/resources/db/migration/V1_4__add_column_in_reviewer.sql
+++ b/src/main/resources/db/migration/V1_4__add_column_in_reviewer.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reviewer ADD score FLOAT NOT NULL DEFAULT 0.0;
+ALTER TABLE reviewer ADD evaluation_cnt BIGINT NOT NULL DEFAULT 1;

--- a/src/main/resources/db/migration/V2_1__add_table_evaluation.sql
+++ b/src/main/resources/db/migration/V2_1__add_table_evaluation.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS evaluation (
+    id              BIGINT          NOT NULL    AUTO_INCREMENT,
+    reviewee_id     BIGINT          NOT NULL,
+    reviewer_id     BIGINT          NOT NULL,
+    review_id       BIGINT          UNIQUE,
+    score           FLOAT           NOT NULL,
+    content         VARCHAR(100)    NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (reviewer_id) REFERENCES reviewer (id) ON DELETE CASCADE
+) ENGINE = InnoDB;

--- a/src/test/java/project/reviewing/integration/IntegrationTest.java
+++ b/src/test/java/project/reviewing/integration/IntegrationTest.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Repository;
 import project.reviewing.auth.domain.RefreshTokenRepository;
 import project.reviewing.common.util.ReviewingTime;
 import project.reviewing.common.util.Time;
+import project.reviewing.evaluation.domain.Evaluation;
+import project.reviewing.evaluation.domain.EvaluationRepository;
 import project.reviewing.member.command.domain.Member;
 import project.reviewing.member.command.domain.MemberRepository;
 import project.reviewing.member.command.domain.Reviewer;
@@ -44,6 +46,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected ReviewRepository reviewRepository;
+
+    @Autowired
+    protected EvaluationRepository evaluationRepository;
 
     @Autowired
     protected Time time;
@@ -96,5 +101,11 @@ public abstract class IntegrationTest {
         final Review savedReview = reviewRepository.save(review);
         entityManager.clear();
         return savedReview;
+    }
+
+    protected Evaluation createEvaluation(final Evaluation evaluation) {
+        final Evaluation savedEvaluation = evaluationRepository.save(evaluation);
+        entityManager.clear();
+        return savedEvaluation;
     }
 }

--- a/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
+++ b/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
@@ -1,0 +1,145 @@
+package project.reviewing.integration.evaluation.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import project.reviewing.common.exception.ErrorType;
+import project.reviewing.evaluation.application.EvaluationService;
+import project.reviewing.evaluation.domain.Evaluation;
+import project.reviewing.evaluation.exception.InvalidEvaluationException;
+import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
+import project.reviewing.integration.IntegrationTest;
+import project.reviewing.member.command.domain.Career;
+import project.reviewing.member.command.domain.Job;
+import project.reviewing.member.command.domain.Member;
+import project.reviewing.member.command.domain.Reviewer;
+import project.reviewing.review.command.domain.Review;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+@DisplayName("EvaluationService는 ")
+public class EvaluationServiceTest extends IntegrationTest {
+
+    private EvaluationService evaluationService;
+
+    @BeforeEach
+    void setUp() {
+        evaluationService = new EvaluationService(memberRepository, reviewRepository, evaluationRepository);
+    }
+
+    @DisplayName("리뷰 평가 생성 시 ")
+    @Nested
+    class EvaluationCreateTest {
+
+        @DisplayName("정상적으로 리뷰 평가가 생성된다.")
+        @Test
+        void validCreateEvaluation() {
+            // given
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
+
+            // when, then
+            assertDoesNotThrow(
+                    () -> evaluationService.createEvaluation(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(), request
+                    ));
+        }
+
+        @DisplayName("이미 해당 리뷰에 대한 평가가 생성되었다면 예외 반환한다.")
+        @Test
+        void createWithAlreadyExistEvaluation() {
+            // given
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+            createEvaluation(
+                    new Evaluation(
+                            review.getId(), reviewee.getId(), reviewerMember.getReviewer().getId(), 3.5F, "평가 내용"
+                    ));
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
+
+            // when, then
+            assertThatThrownBy(
+                    () -> evaluationService.createEvaluation(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(), request
+                    ))
+                    .isInstanceOf(InvalidEvaluationException.class)
+                    .hasMessage(ErrorType.ALREADY_EVALUATED.getMessage());
+        }
+
+        @DisplayName("해당 리뷰를 작성한 리뷰이가 아니라면 예외 반환한다.")
+        @Test
+        void createWithNotRevieweeOfReview() {
+            // given
+            final Long invalidRevieweeId = -1L;
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
+
+            // when, then
+            assertThatThrownBy(
+                    () -> evaluationService.createEvaluation(
+                            invalidRevieweeId, reviewerMember.getReviewer().getId(), request
+                    ))
+                    .isInstanceOf(InvalidEvaluationException.class)
+                    .hasMessage(ErrorType.NOT_REVIEWEE_OF_REVIEW.getMessage());
+        }
+
+        @DisplayName("해당 리뷰를 요청받은 리뷰어가 아니라면 예외 반환한다.")
+        @Test
+        void createWithNotReviewerOfReview() {
+            // given
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Member invalidReviewerMember = createMemberAndRegisterReviewer(
+                    new Member(3L, "sioh", "sioh@gmail.com", "imageUrl", "https://github.com/sioh"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
+
+            // when, then
+            assertThatThrownBy(
+                    () -> evaluationService.createEvaluation(
+                            reviewee.getId(), invalidReviewerMember.getReviewer().getId(), request
+                    ))
+                    .isInstanceOf(InvalidEvaluationException.class)
+                    .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
+        }
+    }
+}

--- a/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
+++ b/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
@@ -15,6 +15,7 @@ import project.reviewing.member.command.domain.Job;
 import project.reviewing.member.command.domain.Member;
 import project.reviewing.member.command.domain.Reviewer;
 import project.reviewing.review.command.domain.Review;
+import project.reviewing.review.exception.InvalidReviewException;
 
 import java.util.Set;
 
@@ -51,6 +52,11 @@ public class EvaluationServiceTest extends IntegrationTest {
                     ));
             final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
 
+            review.approve(time);
+            entityManager.merge(review);
+            entityManager.flush();
+            entityManager.clear();
+
             // when, then
             assertDoesNotThrow(
                     () -> evaluationService.createEvaluation(
@@ -78,6 +84,11 @@ public class EvaluationServiceTest extends IntegrationTest {
                     ));
             final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
 
+            review.approve(time);
+            entityManager.merge(review);
+            entityManager.flush();
+            entityManager.clear();
+
             // when, then
             assertThatThrownBy(
                     () -> evaluationService.createEvaluation(
@@ -104,12 +115,17 @@ public class EvaluationServiceTest extends IntegrationTest {
                     ));
             final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
 
+            review.approve(time);
+            entityManager.merge(review);
+            entityManager.flush();
+            entityManager.clear();
+
             // when, then
             assertThatThrownBy(
                     () -> evaluationService.createEvaluation(
                             invalidRevieweeId, reviewerMember.getReviewer().getId(), request
                     ))
-                    .isInstanceOf(InvalidEvaluationException.class)
+                    .isInstanceOf(InvalidReviewException.class)
                     .hasMessage(ErrorType.NOT_REVIEWEE_OF_REVIEW.getMessage());
         }
 
@@ -133,12 +149,17 @@ public class EvaluationServiceTest extends IntegrationTest {
                     ));
             final EvaluationCreateRequest request = new EvaluationCreateRequest(review.getId(), 3.5F, "평가 내용");
 
+            review.approve(time);
+            entityManager.merge(review);
+            entityManager.flush();
+            entityManager.clear();
+
             // when, then
             assertThatThrownBy(
                     () -> evaluationService.createEvaluation(
                             reviewee.getId(), invalidReviewerMember.getReviewer().getId(), request
                     ))
-                    .isInstanceOf(InvalidEvaluationException.class)
+                    .isInstanceOf(InvalidReviewException.class)
                     .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
         }
     }

--- a/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
+++ b/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
@@ -371,11 +371,11 @@ public class ReviewServiceTest extends IntegrationTest {
 
     @DisplayName("리뷰 종료 시")
     @Nested
-    class ReviewFinishTest {
+    class ReviewCloseTest {
 
         @DisplayName("정상적으로 종료된다.")
         @Test
-        void validFinishReview() {
+        void validCloseReview() {
             final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
             final Member reviewerMember = createMemberAndRegisterReviewer(
                     new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
@@ -390,7 +390,7 @@ public class ReviewServiceTest extends IntegrationTest {
             reviewService.refuseReview(reviewerMember.getId(), review.getId());
             entityManager.flush();
             entityManager.clear();
-            reviewService.finishReview(reviewerMember.getId(), review.getId());
+            reviewService.closeReview(reviewerMember.getId(), review.getId());
             entityManager.flush();
             entityManager.clear();
 
@@ -399,20 +399,20 @@ public class ReviewServiceTest extends IntegrationTest {
 
         @DisplayName("리뷰 정보가 없으면 예외 발생한다.")
         @Test
-        void refuseWithNotExistReview() {
+        void closeWithNotExistReview() {
             final Long invalidReviewId = -1L;
             final Member reviewerMember = createMemberAndRegisterReviewer(
                     new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
                     new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
             );
 
-            assertThatThrownBy(() -> reviewService.finishReview(reviewerMember.getId(), invalidReviewId))
+            assertThatThrownBy(() -> reviewService.closeReview(reviewerMember.getId(), invalidReviewId))
                     .isInstanceOf(ReviewNotFoundException.class);
         }
 
         @DisplayName("요청한 회원 정보가 없으면 예외 발생한다.")
         @Test
-        void refuseWithNotExistMember() {
+        void closeWithNotExistMember() {
             final Long invalidMemberId = -1L;
             final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
             final Member reviewerMember = createMemberAndRegisterReviewer(
@@ -425,7 +425,7 @@ public class ReviewServiceTest extends IntegrationTest {
                             "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
                     ));
 
-            assertThatThrownBy(() -> reviewService.finishReview(invalidMemberId, review.getId()))
+            assertThatThrownBy(() -> reviewService.closeReview(invalidMemberId, review.getId()))
                     .isInstanceOf(MemberNotFoundException.class);
         }
     }

--- a/src/test/java/project/reviewing/unit/ControllerTest.java
+++ b/src/test/java/project/reviewing/unit/ControllerTest.java
@@ -7,19 +7,23 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.bind.annotation.RestController;
 import project.reviewing.auth.application.AuthService;
 import project.reviewing.auth.domain.RefreshTokenRepository;
 import project.reviewing.auth.infrastructure.TokenProvider;
 import project.reviewing.auth.presentation.AuthContext;
-import project.reviewing.auth.presentation.AuthInterceptor;
-import project.reviewing.auth.presentation.RefreshInterceptor;
 import project.reviewing.member.command.application.MemberService;
 import project.reviewing.member.query.application.MemberQueryService;
 import project.reviewing.review.query.application.ReviewQueryService;
 import project.reviewing.tag.query.application.TagQueryService;
 import project.reviewing.review.command.application.ReviewService;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class))
 @Import({
@@ -56,4 +60,20 @@ public class ControllerTest {
 
     @MockBean
     protected TagQueryService tagQueryService;
+
+    protected ResultActions requestHttp(
+            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder, final Object request
+    ) throws Exception {
+        final String accessToken = tokenProvider.createAccessToken(1L);
+        return mockMvc.perform(mockHttpServletRequestBuilder
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("UTF-8")
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print());
+    }
+
+    protected String makeStringByLength(final int length) {
+        return "A".repeat(length);
+    }
 }

--- a/src/test/java/project/reviewing/unit/ControllerTest.java
+++ b/src/test/java/project/reviewing/unit/ControllerTest.java
@@ -17,6 +17,7 @@ import project.reviewing.auth.application.AuthService;
 import project.reviewing.auth.domain.RefreshTokenRepository;
 import project.reviewing.auth.infrastructure.TokenProvider;
 import project.reviewing.auth.presentation.AuthContext;
+import project.reviewing.evaluation.application.EvaluationService;
 import project.reviewing.member.command.application.MemberService;
 import project.reviewing.member.query.application.MemberQueryService;
 import project.reviewing.review.query.application.ReviewQueryService;
@@ -56,10 +57,13 @@ public class ControllerTest {
     protected ReviewQueryService reviewQueryService;
 
     @MockBean
-    protected RefreshTokenRepository refreshTokenRepository;
+    protected TagQueryService tagQueryService;
 
     @MockBean
-    protected TagQueryService tagQueryService;
+    protected EvaluationService evaluationService;
+
+    @MockBean
+    protected RefreshTokenRepository refreshTokenRepository;
 
     protected ResultActions requestHttp(
             final MockHttpServletRequestBuilder mockHttpServletRequestBuilder, final Object request

--- a/src/test/java/project/reviewing/unit/evaluation/presentation/EvaluationControllerTest.java
+++ b/src/test/java/project/reviewing/unit/evaluation/presentation/EvaluationControllerTest.java
@@ -1,0 +1,91 @@
+package project.reviewing.unit.evaluation.presentation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
+import project.reviewing.unit.ControllerTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("EvaluationController는 ")
+public class EvaluationControllerTest extends ControllerTest {
+
+    @DisplayName("리뷰 평가 생성 시 ")
+    @Nested
+    class EvaluationCreateTest {
+
+        @DisplayName("요청이 유효하면 200 반환한다.")
+        @Test
+        void validCreateEvaluation() throws Exception {
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(1L, 3.5F, "평가 내용");
+
+            requestHttp(post("/reviewers/1/evaluations"), request)
+                    .andExpect(status().isOk());
+        }
+
+        @DisplayName("reviewId가 null이면 400 반환한다.")
+        @Test
+        void createWithReviewIdNull() throws Exception {
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(null, 3.5F, "평가 내용");
+
+            requestHttp(post("/reviewers/1/evaluations"), request)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            result -> assertThat(result.getResolvedException())
+                                    .isInstanceOf(MethodArgumentNotValidException.class)
+                    );
+        }
+
+        @DisplayName("score가 null이거나 제한 범위를 벗어났다면 400 반환한다.")
+        @ValueSource(floats = {-0.1F, 5.1F})
+        @NullSource
+        @ParameterizedTest
+        void createWithTitleGreaterThanMaxLen(final Float score) throws Exception {
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(1L, score, "평가 내용");
+
+            requestHttp(post("/reviewers/1/evaluations"), request)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            result -> assertThat(result.getResolvedException())
+                                    .isInstanceOf(MethodArgumentNotValidException.class)
+                    );
+        }
+
+        @DisplayName("content가 null, empty, blank면 400 반환한다.")
+        @NullAndEmptySource
+        @ValueSource(strings = {" "})
+        @ParameterizedTest
+        void createWithContentNullAndEmpty(final String content) throws Exception {
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(null, 3.5F, content);
+
+            requestHttp(post("/reviewers/1/evaluations"), request)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            result -> assertThat(result.getResolvedException())
+                                    .isInstanceOf(MethodArgumentNotValidException.class)
+                    );
+        }
+
+        @DisplayName("content가 제한 길이 100자보다 길면 400 반환한다.")
+        @Test
+        void createWithContentGreaterThanMaxLen() throws Exception {
+            final String content = makeStringByLength(101);
+            final EvaluationCreateRequest request = new EvaluationCreateRequest(null, 3.5F, content);
+
+            requestHttp(post("/reviewers/1/evaluations"), request)
+                    .andExpectAll(
+                            status().isBadRequest(),
+                            result -> assertThat(result.getResolvedException())
+                                    .isInstanceOf(MethodArgumentNotValidException.class)
+                    );
+        }
+    }
+}

--- a/src/test/java/project/reviewing/unit/member/domain/MemberTest.java
+++ b/src/test/java/project/reviewing/unit/member/domain/MemberTest.java
@@ -75,4 +75,19 @@ public class MemberTest {
 
         assertThat(sut.isReviewer()).isFalse();
     }
+
+    @DisplayName("리뷰어의 평점과 평가 개수를 갱신할 수 있다.")
+    @Test
+    void updateReviewerScore() {
+        final Member sut = new Member(1L, "username", "email@gmail.com", "image.png", "github.com/profile");
+        final Reviewer reviewer = new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L, 2L), "안녕하세요");
+        sut.register(reviewer);
+
+        sut.updateReviewerScore(3.5F);
+
+        assertAll(
+                () -> assertThat(sut.getReviewer().getEvaluationCnt()).isEqualTo(1),
+                () -> assertThat(sut.getReviewer().getScore()).isEqualTo(3.5F)
+        );
+    }
 }

--- a/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
+++ b/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
@@ -192,30 +192,30 @@ public class ReviewTest {
 
     @DisplayName("리뷰를 종료할 수 있는지 조건을 확인할 수 있다.")
     @Test
-    void validFinishReview() {
+    void validCloseReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
         review.refuse(time);
 
-        assertThat(review.canFinish(1L)).isTrue();
+        assertThat(review.canClose(1L)).isTrue();
     }
 
     @DisplayName("리뷰를 요청받은 리뷰어가 아니면 종료할 수 없다.")
     @Test
-    void finishWithNotReviewerOfReview() {
+    void closeWithNotReviewerOfReview() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
-        assertThatThrownBy(() -> review.canFinish(2L))
+        assertThatThrownBy(() -> review.canClose(2L))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
     }
 
     @DisplayName("리뷰의 상태가 REFUSED(거절) 상태가 아니면 종료할 수 없다.")
     @Test
-    void finishWithNotProperStatus() {
+    void closeWithNotProperStatus() {
         final Review review = Review.assign(1L, 1L, "제목", "본문", "prUrl", 2L, true, time);
 
-        assertThatThrownBy(() -> review.canFinish(1L))
+        assertThatThrownBy(() -> review.canClose(1L))
                 .isInstanceOf(InvalidReviewException.class)
                 .hasMessage(ErrorType.NOT_PROPER_REVIEW_STATUS.getMessage());
     }

--- a/src/test/java/project/reviewing/unit/review/presentation/ReviewControllerTest.java
+++ b/src/test/java/project/reviewing/unit/review/presentation/ReviewControllerTest.java
@@ -38,7 +38,7 @@ public class ReviewControllerTest extends ControllerTest {
                     "리뷰 요청합니다.", "본문", "https://github.com/Tom/myproject/pull/1"
             );
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpect(status().isOk());
         }
 
@@ -51,7 +51,7 @@ public class ReviewControllerTest extends ControllerTest {
                     title, "본문", "https://github.com/Tom/myproject/pull/1"
             );
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -67,7 +67,7 @@ public class ReviewControllerTest extends ControllerTest {
                     title, "본문", "https://github.com/Tom/myproject/pull/1"
             );
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -84,7 +84,7 @@ public class ReviewControllerTest extends ControllerTest {
                     "리뷰 요청합니다.", content, "https://github.com/Tom/myproject/pull/1"
             );
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -100,7 +100,7 @@ public class ReviewControllerTest extends ControllerTest {
                     "리뷰 요청합니다.", content, "https://github.com/Tom/myproject/pull/1"
             );
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -115,7 +115,7 @@ public class ReviewControllerTest extends ControllerTest {
         void createWithPrUrlNullAndEmpty(final String prUrl) throws Exception {
             final ReviewCreateRequest request = new ReviewCreateRequest("리뷰 요청합니다.", "본문", prUrl);
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -133,7 +133,7 @@ public class ReviewControllerTest extends ControllerTest {
         void createWithInvalidPrUrl(final String prUrl) throws Exception {
             final ReviewCreateRequest request = new ReviewCreateRequest("리뷰 요청합니다.", "본문", prUrl);
 
-            requestAboutReview(post("/reviewers/1/reviews"), request)
+            requestHttp(post("/reviewers/1/reviews"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -149,7 +149,7 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("요청이 유효하면 200 반환한다.")
         @Test
         void validReadSingleReview() throws Exception {
-            requestAboutReview(get("/reviewers/1/reviews/1"), null)
+            requestHttp(get("/reviewers/1/reviews/1"), null)
                     .andExpect(status().isOk());
         }
     }
@@ -162,7 +162,7 @@ public class ReviewControllerTest extends ControllerTest {
         @ValueSource(strings = {"reviewee", "reviewer"})
         @ParameterizedTest
         void validReadReviewsByRole(final String role) throws Exception {
-            requestAboutReview(get("/reviews?role=" + role), null)
+            requestHttp(get("/reviews?role=" + role), null)
                     .andExpect(status().isOk());
         }
 
@@ -174,7 +174,7 @@ public class ReviewControllerTest extends ControllerTest {
         })
         @ParameterizedTest
         void validReadReviewsByRoleWithStatus(final String role, final String status) throws Exception {
-            requestAboutReview(get("/reviews?role=" + role + "&status=" + status), null)
+            requestHttp(get("/reviews?role=" + role + "&status=" + status), null)
                     .andExpect(status().isOk());
         }
 
@@ -182,7 +182,7 @@ public class ReviewControllerTest extends ControllerTest {
         @ValueSource(strings = {"abc", "", " "})
         @ParameterizedTest
         void readWithInvalidRole(final String role) throws Exception {
-            requestAboutReview(get("/reviews?role=" + role), null)
+            requestHttp(get("/reviews?role=" + role), null)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -194,7 +194,7 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("role이 포함되지 않으면 400 반환한다.")
         @Test
         void readWithNotExistRole() throws Exception {
-            requestAboutReview(get("/reviews"), null)
+            requestHttp(get("/reviews"), null)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -206,7 +206,7 @@ public class ReviewControllerTest extends ControllerTest {
         @ValueSource(strings = {"abc", "", " "})
         @ParameterizedTest
         void readWithInvalidStatus(final String status) throws Exception {
-            requestAboutReview(get("/reviews?role=reviewer&status=" + status), null)
+            requestHttp(get("/reviews?role=reviewer&status=" + status), null)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -225,7 +225,7 @@ public class ReviewControllerTest extends ControllerTest {
         void validUpdateReview() throws Exception {
             final ReviewUpdateRequest request = new ReviewUpdateRequest("본문");
 
-            requestAboutReview(patch("/reviewers/1/reviews/1"), request)
+            requestHttp(patch("/reviewers/1/reviews/1"), request)
                     .andExpect(status().isNoContent());
         }
 
@@ -236,7 +236,7 @@ public class ReviewControllerTest extends ControllerTest {
         void updateWithContentNullAndEmpty(final String content) throws Exception {
             final ReviewUpdateRequest request = new ReviewUpdateRequest(content);
 
-            requestAboutReview(patch("/reviewers/1/reviews/1"), request)
+            requestHttp(patch("/reviewers/1/reviews/1"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -250,7 +250,7 @@ public class ReviewControllerTest extends ControllerTest {
             final String content = makeStringByLength(1501);
             final ReviewUpdateRequest request = new ReviewUpdateRequest(content);
 
-            requestAboutReview(patch("/reviewers/1/reviews/1"), request)
+            requestHttp(patch("/reviewers/1/reviews/1"), request)
                     .andExpectAll(
                             status().isBadRequest(),
                             result -> assertThat(result.getResolvedException())
@@ -266,7 +266,7 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("요청이 유효하면 204 반환한다.")
         @Test
         void validAcceptReview() throws Exception {
-            requestAboutReview(patch("/reviewers/1/reviews/1/status-accepted"), null)
+            requestHttp(patch("/reviewers/1/reviews/1/status-accepted"), null)
                     .andExpect(status().isNoContent());
         }
     }
@@ -278,7 +278,7 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("요청이 유효하면 204 반환한다.")
         @Test
         void validAcceptReview() throws Exception {
-            requestAboutReview(patch("/reviewers/1/reviews/1/status-refused"), null)
+            requestHttp(patch("/reviewers/1/reviews/1/status-refused"), null)
                     .andExpect(status().isNoContent());
         }
     }
@@ -290,7 +290,7 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("요청이 유효하면 204 반환한다.")
         @Test
         void validAcceptReview() throws Exception {
-            requestAboutReview(patch("/reviewers/1/reviews/1/status-approved"), null)
+            requestHttp(patch("/reviewers/1/reviews/1/status-approved"), null)
                     .andExpect(status().isNoContent());
         }
     }
@@ -302,24 +302,8 @@ public class ReviewControllerTest extends ControllerTest {
         @DisplayName("요청이 유효하면 204 반환한다.")
         @Test
         void validAcceptReview() throws Exception {
-            requestAboutReview(delete("/reviewers/1/reviews/1"), null)
+            requestHttp(delete("/reviewers/1/reviews/1"), null)
                     .andExpect(status().isNoContent());
         }
-    }
-
-    private ResultActions requestAboutReview(
-            final MockHttpServletRequestBuilder mockHttpServletRequestBuilder, final Object request
-    ) throws Exception {
-        final String accessToken = tokenProvider.createAccessToken(1L);
-        return mockMvc.perform(mockHttpServletRequestBuilder
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("UTF-8")
-                .content(objectMapper.writeValueAsString(request)))
-                .andDo(print());
-    }
-
-    private String makeStringByLength(final int length) {
-        return "A".repeat(length);
     }
 }


### PR DESCRIPTION
## 상세 내용

- 리뷰 상태 EVALUATED ( 평가 ) 추가
- 리뷰 평가 생성 API 추가
- 완료 상태의 리뷰 목록 조회 시 평가 상태도 같이 조회되도록 구현
- Flyway DB Migration 파일 추가
- 테스트 코드 작성

## 주의 사항

- DB 스키마 중 잘못 설계 된 것을 발견하여 스키마 수정을 위한 Flyway DB Migration 파일 추가
   - Review Table의 reviewer_id와 reviewee_id의 fk 제약 조건 제거
      - 이유는 Review Entity는 Reviewer와 Member Entity가 지워져도 지워지지 말아야 하고, Reviewer와 Member Entity는 Review Entity와 상관 없이 지울 수 있어야 하는 요구 사항 때문

Close #69