### PR TITLE
[#74] 단일 리뷰 평가 조회 기능 구현

### DIFF
--- a/src/main/java/project/reviewing/common/exception/ErrorType.java
+++ b/src/main/java/project/reviewing/common/exception/ErrorType.java
@@ -32,7 +32,8 @@ public enum ErrorType {
     NOT_PROPER_REVIEW_STATUS("REVIEW-006", "리뷰의 상태가 적절하지 않습니다."),
     ROLE_IN_REVIEW_NOT_FOUND("REVIEW-007", "해당 리뷰의 역할을 찾을 수 없습니다."),
 
-    ALREADY_EVALUATED("EVALUATION-001", "이미 해당 리뷰에 대한 평가가 되었습니다.")
+    ALREADY_EVALUATED("EVALUATION-001", "이미 해당 리뷰에 대한 평가가 되었습니다."),
+    EVALUATION_NOT_FOUND("EVALUATION-002", "해당 평가를 찾을 수 없습니다.")
     ;
 
     private final String code;

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.reviewing.common.exception.ErrorType;
+import project.reviewing.evaluation.application.response.SingleEvaluationResponse;
 import project.reviewing.evaluation.domain.Evaluation;
 import project.reviewing.evaluation.domain.EvaluationRepository;
+import project.reviewing.evaluation.exception.EvaluationNotFoundException;
 import project.reviewing.evaluation.exception.InvalidEvaluationException;
 import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
 import project.reviewing.member.command.domain.Member;
@@ -45,5 +47,12 @@ public class EvaluationService {
             Evaluation evaluation = evaluationCreateRequest.toEntity(reviewerId, memberId);
             evaluationRepository.save(evaluation);
         }
+    }
+
+    public SingleEvaluationResponse findSingleEvaluationByReviewId(final Long reviewId) {
+        final Evaluation evaluation = evaluationRepository.findByReviewId(reviewId)
+                .orElseThrow(EvaluationNotFoundException::new);
+
+        return SingleEvaluationResponse.from(evaluation);
     }
 }

--- a/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/application/EvaluationService.java
@@ -49,6 +49,7 @@ public class EvaluationService {
         }
     }
 
+    @Transactional(readOnly = true)
     public SingleEvaluationResponse findSingleEvaluationByReviewId(final Long reviewId) {
         final Evaluation evaluation = evaluationRepository.findByReviewId(reviewId)
                 .orElseThrow(EvaluationNotFoundException::new);

--- a/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
+++ b/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
@@ -1,7 +1,9 @@
 package project.reviewing.evaluation.application.response;
 
+import lombok.Getter;
 import project.reviewing.evaluation.domain.Evaluation;
 
+@Getter
 public class SingleEvaluationResponse {
 
     private Long id;

--- a/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
+++ b/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
@@ -1,0 +1,4 @@
+package project.reviewing.evaluation.application.response;
+
+public class SingleEvaluationResponse {
+}

--- a/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
+++ b/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
@@ -1,4 +1,22 @@
 package project.reviewing.evaluation.application.response;
 
+import project.reviewing.evaluation.domain.Evaluation;
+
 public class SingleEvaluationResponse {
+
+    private Long id;
+    private Float score;
+    private String content;
+
+    public static SingleEvaluationResponse from(final Evaluation evaluation) {
+        return new SingleEvaluationResponse(evaluation.getId(), evaluation.getScore(), evaluation.getContent());
+    }
+
+    public SingleEvaluationResponse() {}
+
+    private SingleEvaluationResponse(final Long id, final Float score, final String content) {
+        this.id = id;
+        this.score = score;
+        this.content = content;
+    }
 }

--- a/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
+++ b/src/main/java/project/reviewing/evaluation/application/response/SingleEvaluationResponse.java
@@ -6,15 +6,13 @@ import project.reviewing.evaluation.domain.Evaluation;
 @Getter
 public class SingleEvaluationResponse {
 
-    private Long id;
-    private Float score;
-    private String content;
+    private final Long id;
+    private final Float score;
+    private final String content;
 
     public static SingleEvaluationResponse from(final Evaluation evaluation) {
         return new SingleEvaluationResponse(evaluation.getId(), evaluation.getScore(), evaluation.getContent());
     }
-
-    public SingleEvaluationResponse() {}
 
     private SingleEvaluationResponse(final Long id, final Float score, final String content) {
         this.id = id;

--- a/src/main/java/project/reviewing/evaluation/domain/Evaluation.java
+++ b/src/main/java/project/reviewing/evaluation/domain/Evaluation.java
@@ -1,10 +1,12 @@
 package project.reviewing.evaluation.domain;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Evaluation {

--- a/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
+++ b/src/main/java/project/reviewing/evaluation/domain/EvaluationRepository.java
@@ -9,4 +9,5 @@ public interface EvaluationRepository extends Repository<Evaluation, Long> {
     boolean existsByReviewId(Long reviewId);
     Evaluation save(Evaluation entity);
     Optional<Evaluation> findById(Long id);
+    Optional<Evaluation> findByReviewId(Long reviewId);
 }

--- a/src/main/java/project/reviewing/evaluation/exception/EvaluationNotFoundException.java
+++ b/src/main/java/project/reviewing/evaluation/exception/EvaluationNotFoundException.java
@@ -1,0 +1,11 @@
+package project.reviewing.evaluation.exception;
+
+import project.reviewing.common.exception.BadRequestException;
+import project.reviewing.common.exception.ErrorType;
+
+public class EvaluationNotFoundException extends BadRequestException {
+
+    public EvaluationNotFoundException() {
+        super(ErrorType.EVALUATION_NOT_FOUND);
+    }
+}

--- a/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
@@ -25,10 +25,7 @@ public class EvaluationController {
     }
 
     @GetMapping("/evaluations/{review-id}")
-    public SingleEvaluationResponse readSingleEvaluation(
-            @AuthenticatedMember final Long memberId,
-            @PathVariable("review-id") final Long reviewId
-    ) {
-        return new SingleEvaluationResponse();
+    public SingleEvaluationResponse readSingleEvaluation(@PathVariable("review-id") final Long reviewId) {
+        return evaluationService.findSingleEvaluationByReviewId(reviewId);
     }
 }

--- a/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
+++ b/src/main/java/project/reviewing/evaluation/presentation/EvaluationController.java
@@ -1,12 +1,10 @@
 package project.reviewing.evaluation.presentation;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import project.reviewing.auth.presentation.AuthenticatedMember;
 import project.reviewing.evaluation.application.EvaluationService;
+import project.reviewing.evaluation.application.response.SingleEvaluationResponse;
 import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
 
 import javax.validation.Valid;
@@ -24,5 +22,13 @@ public class EvaluationController {
             @Valid @RequestBody final EvaluationCreateRequest evaluationCreateRequest
     ) {
         evaluationService.createEvaluation(memberId, reviewerId, evaluationCreateRequest);
+    }
+
+    @GetMapping("/evaluations/{review-id}")
+    public SingleEvaluationResponse readSingleEvaluation(
+            @AuthenticatedMember final Long memberId,
+            @PathVariable("review-id") final Long reviewId
+    ) {
+        return new SingleEvaluationResponse();
     }
 }

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -110,26 +110,6 @@ public class Review {
         return true;
     }
 
-    public boolean isExpiredInCreatedStatus() {
-        return (status == ReviewStatus.CREATED) && isExpired();
-    }
-
-    public boolean isExpiredInAcceptedStatus() {
-        return (status == ReviewStatus.ACCEPTED) && isExpired();
-    }
-
-    public boolean isExpiredInRefusedStatus() {
-        return (status == ReviewStatus.REFUSED) && isExpired();
-    }
-
-    public boolean isExpiredInApprovedStatus() {
-        return (status == ReviewStatus.APPROVED) && isExpired();
-    }
-
-    public LocalDateTime findExpireDate() {
-        return statusSetAt.plusDays(3);
-    }
-
     public void checkReviewer(final Long reviewerId) {
         if (!this.reviewerId.equals(reviewerId)) {
             throw new InvalidReviewException(ErrorType.NOT_REVIEWER_OF_REVIEW);
@@ -140,6 +120,20 @@ public class Review {
         if (!this.revieweeId.equals(revieweeId)) {
             throw new InvalidReviewException(ErrorType.NOT_REVIEWEE_OF_REVIEW);
         }
+    }
+
+    public boolean isTimeToChangeToRefusedStatus() {
+        return (status == ReviewStatus.CREATED || status == ReviewStatus.ACCEPTED)
+                && isExpired();
+    }
+
+    public boolean isTimeToRemove() {
+        return (status == ReviewStatus.REFUSED || status == ReviewStatus.APPROVED || status == ReviewStatus.EVALUATED)
+                && isExpired();
+    }
+
+    public LocalDateTime findExpireDate() {
+        return statusSetAt.plusDays(status.getExpirePeriod());
     }
 
     private void checkStatusCreated() {

--- a/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewStatus.java
@@ -1,16 +1,25 @@
 package project.reviewing.review.command.domain;
 
+import lombok.Getter;
+
 import java.util.Arrays;
 
+@Getter
 public enum ReviewStatus {
 
-    NONE,
-    CREATED,
-    ACCEPTED,
-    REFUSED,
-    APPROVED,
-    EVALUATED
+    NONE(0),
+    CREATED(3),
+    ACCEPTED(5),
+    REFUSED(3),
+    APPROVED(3),
+    EVALUATED(3)
     ;
+
+    private final int expirePeriod;
+
+    ReviewStatus(int expirePeriod) {
+        this.expirePeriod = expirePeriod;
+    }
 
     public static boolean isContain(final String name) {
         return Arrays.stream(values())

--- a/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
@@ -23,9 +23,9 @@ public class ReviewScheduler {
         final List<Review> reviews = reviewRepository.findAll();
 
         for (Review review : reviews) {
-            if (review.isExpiredInCreatedStatus() || review.isExpiredInAcceptedStatus()) {
+            if (review.isTimeToChangeToRefusedStatus()) {
                 review.refuse(time);
-            } else if (review.isExpiredInRefusedStatus() || review.isExpiredInApprovedStatus()) {
+            } else if (review.isTimeToRemove()) {
                 reviewRepository.delete(review);
             }
         }

--- a/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
+++ b/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import project.reviewing.common.exception.ErrorType;
 import project.reviewing.evaluation.application.EvaluationService;
+import project.reviewing.evaluation.application.response.SingleEvaluationResponse;
 import project.reviewing.evaluation.domain.Evaluation;
+import project.reviewing.evaluation.exception.EvaluationNotFoundException;
 import project.reviewing.evaluation.exception.InvalidEvaluationException;
 import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
 import project.reviewing.integration.IntegrationTest;
@@ -19,7 +21,9 @@ import project.reviewing.review.exception.InvalidReviewException;
 
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 @DisplayName("EvaluationService는 ")
@@ -161,6 +165,52 @@ public class EvaluationServiceTest extends IntegrationTest {
                     ))
                     .isInstanceOf(InvalidReviewException.class)
                     .hasMessage(ErrorType.NOT_REVIEWER_OF_REVIEW.getMessage());
+        }
+    }
+
+    @DisplayName("단일 리뷰 평가 조회 시 ")
+    @Nested
+    class SingleEvaluationFindTest {
+
+        @DisplayName("정상적으로 조회된다.")
+        @Test
+        void validFindSingleEvaluation() {
+            // given
+            final Member reviewee = createMember(new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom"));
+            final Member reviewerMember = createMemberAndRegisterReviewer(
+                    new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor"),
+                    new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글")
+            );
+            final Review review = createReview(
+                    Review.assign(
+                            reviewee.getId(), reviewerMember.getReviewer().getId(),
+                            "제목", "본문", "prUrl", reviewerMember.getId(), reviewerMember.isReviewer(), time
+                    ));
+            final Evaluation evaluation = createEvaluation(
+                    new Evaluation(
+                            review.getId(), reviewee.getId(), reviewerMember.getReviewer().getId(), 3.5F, "평가 내용"
+                    ));
+
+            // when, then
+            final SingleEvaluationResponse response = evaluationService.findSingleEvaluationByReviewId(review.getId());
+
+            assertAll(
+                    () -> assertThat(response.getId()).isEqualTo(evaluation.getId()),
+                    () -> assertThat(response.getScore()).isEqualTo(evaluation.getScore()),
+                    () -> assertThat(response.getContent()).isEqualTo(evaluation.getContent())
+            );
+        }
+
+        @DisplayName("평가 데이터가 없으면 예외 반환한다.")
+        @Test
+        void findWithNotRevieweeOfReview() {
+            // given
+            final Long invalidReviewId = -1L;
+
+            // when, then
+            assertThatThrownBy(() -> evaluationService.findSingleEvaluationByReviewId(invalidReviewId))
+                    .isInstanceOf(EvaluationNotFoundException.class)
+                    .hasMessage(ErrorType.EVALUATION_NOT_FOUND.getMessage());
         }
     }
 }

--- a/src/test/java/project/reviewing/unit/evaluation/presentation/EvaluationControllerTest.java
+++ b/src/test/java/project/reviewing/unit/evaluation/presentation/EvaluationControllerTest.java
@@ -12,6 +12,7 @@ import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest
 import project.reviewing.unit.ControllerTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -86,6 +87,18 @@ public class EvaluationControllerTest extends ControllerTest {
                             result -> assertThat(result.getResolvedException())
                                     .isInstanceOf(MethodArgumentNotValidException.class)
                     );
+        }
+    }
+
+    @DisplayName("단일 리뷰 평가 조회 시 ")
+    @Nested
+    class SingleEvaluationReadTest {
+
+        @DisplayName("요청이 유효하면 200 반환한다.")
+        @Test
+        void validReadSingleEvaluation() throws Exception {
+            requestHttp(get("/evaluations/1"), null)
+                    .andExpect(status().isOk());
         }
     }
 }


### PR DESCRIPTION
## 상세 내용

- 리뷰 평가 조회 API 추가
   - 리뷰 id로 조회
- 리뷰 상태 정보인 ReviewStatus Enum Class에 '리뷰 상태 만료 시간' 필드 추가하는 방향으로 리팩터링
- 평가 된 리뷰에 대한 Scheduling 로직 추가
- 특정 Review가 Scheduler에 의해 처리되어야 하는지에 대한 확인 로직 리팩터링
   - 기존에는 Review 상태를 기준으로 Method를 만들었다면, 이번에는 '어떻게 처리되어야 하는가'에 초점을 맞추어 '이 Review는 이렇게 처리되어야 하는 상태인가?' 관점으로 Method를 분리
- 기존의 리뷰 수락 후에 만료되어 거절 상태로 바뀌기 까지의 기간을 3일 -> 5일로 변경
- 테스트 코드 작성

## 주의 사항

- 리팩터링 하면서 관련 된 만료기간 바꿔야 하는 작업을 진행 ( 따로 수정하기에는 매우 작은 작업 )
- 리뷰 평가 생성 API 기능을 구현하는 과정에서 Scheduling 로직이 추가되지 않아 이번에 추가

Close #74