### PR TITLE
[#93] 리뷰어 목록 조회 성능 개선

### DIFF
--- a/src/main/java/project/reviewing/member/command/domain/MemberRepository.java
+++ b/src/main/java/project/reviewing/member/command/domain/MemberRepository.java
@@ -12,6 +12,6 @@ public interface MemberRepository extends Repository<Member, Long> {
     Optional<Member> findById(Long id);
     Optional<Member> findByGithubId(Long githubId);
 
-    @Query("SELECT m FROM Member m INNER JOIN m.reviewer r WHERE r.id = :reviewerId")
+    @Query("SELECT m FROM Member m JOIN FETCH m.reviewer r WHERE r.id = :reviewerId")
     Optional<Member> findByReviewerId(@Param("reviewerId") Long reviewerId);
 }

--- a/src/main/java/project/reviewing/member/command/domain/Reviewer.java
+++ b/src/main/java/project/reviewing/member/command/domain/Reviewer.java
@@ -16,6 +16,7 @@ import javax.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -39,9 +40,11 @@ public class Reviewer {
 
     private String introduction;
 
+    @ColumnDefault("0.0")
     @Column(nullable = false)
     private Float score;
 
+    @ColumnDefault("0")
     @Column(nullable = false)
     private Long evaluationCnt;
 

--- a/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
+++ b/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
@@ -71,7 +71,7 @@ public class ReviewerDao {
     }
 
     public Slice<ReviewerData> findByTag(final Pageable pageable, final Long categoryId, final List<Long> tagIds) {
-        String sql = "SELECT /*! STRAIGHT_JOIN */ r.job, r.career, r.introduction, r.id, r.score, m.username, m.image_url, m.profile_url, t.id tag_id, t.name tag_name "
+        String sql = "SELECT r.job, r.career, r.introduction, r.id, r.score, m.username, m.image_url, m.profile_url, t.id tag_id, t.name tag_name "
                 + "FROM reviewer r "
                 + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
                 + "JOIN tag t ON rt.tag_id = t.id "
@@ -96,7 +96,7 @@ public class ReviewerDao {
         if (tagIds != null) {
             tagIdSet.addAll(tagIds);
         }
-        final String sql = "SELECT /*! STRAIGHT_JOIN */ rt.reviewer_id "
+        final String sql = "SELECT rt.reviewer_id "
                 + "FROM reviewer_tag rt "
                 + "JOIN reviewer r ON rt.reviewer_id = r.id "
                 + "JOIN member m ON r.member_id = m.id "

--- a/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
+++ b/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
@@ -71,8 +71,8 @@ public class ReviewerDao {
 
     public Slice<ReviewerData> findByTag(final Pageable pageable, final Long categoryId, final List<Long> tagIds) {
         final String sql = "SELECT /*! STRAIGHT_JOIN */ r.job, r.career, r.introduction, r.id, r.score, m.username, m.image_url, m.profile_url, t.id tag_id, t.name tag_name "
-                + "FROM reviewer_tag rt "
-                + "JOIN reviewer r ON rt.reviewer_id = r.id "
+                + "FROM reviewer r "
+                + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
                 + "JOIN tag t ON rt.tag_id = t.id "
                 + "JOIN member m ON r.member_id = m.id "
                 + "WHERE r.id IN (" + makeReviewerIdsCond(pageable, categoryId, tagIds) + ")";
@@ -83,8 +83,8 @@ public class ReviewerDao {
 
     private String makeReviewerIdsCond(final Pageable pageable, final Long categoryId, final List<Long> tagIds) {
         final String sql = "SELECT /*! STRAIGHT_JOIN */ r.id "
-                + "FROM reviewer_tag rt "
-                + "JOIN reviewer r ON rt.reviewer_id = r.id "
+                + "FROM reviewer r "
+                + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
                 + "JOIN tag t ON rt.tag_id = t.id "
                 + "JOIN member m ON r.member_id = m.id "
                 + "WHERE m.is_reviewer = true AND r.id > :latestId "

--- a/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
+++ b/src/main/java/project/reviewing/member/query/dao/ReviewerDao.java
@@ -70,28 +70,28 @@ public class ReviewerDao {
     }
 
     public Slice<ReviewerData> findByTag(final Pageable pageable, final Long categoryId, final List<Long> tagIds) {
-        final String sql = "SELECT r.job, r.career, r.introduction, r.id, r.score, m.username, m.image_url, m.profile_url, t.id tag_id, t.name tag_name "
-                + "FROM reviewer r "
-                + "JOIN member m ON r.member_id = m.id "
-                + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
+        final String sql = "SELECT /*! STRAIGHT_JOIN */ r.job, r.career, r.introduction, r.id, r.score, m.username, m.image_url, m.profile_url, t.id tag_id, t.name tag_name "
+                + "FROM reviewer_tag rt "
+                + "JOIN reviewer r ON rt.reviewer_id = r.id "
                 + "JOIN tag t ON rt.tag_id = t.id "
+                + "JOIN member m ON r.member_id = m.id "
                 + "WHERE r.id IN "
                 + "( "
-                + "SELECT DISTINCT subquery.sub_rid "
+                + "SELECT subquery.sub_rid "
                 + "FROM ("
-                    + "SELECT DISTINCT r.id sub_rid "
-                    + "FROM reviewer r "
-                    + "JOIN member m ON r.member_id = m.id "
-                    + "JOIN reviewer_tag rt ON r.id = rt.reviewer_id "
+                    + "SELECT /*! STRAIGHT_JOIN */ r.id sub_rid "
+                    + "FROM reviewer_tag rt "
+                    + "JOIN reviewer r ON rt.reviewer_id = r.id "
                     + "JOIN tag t ON rt.tag_id = t.id "
-                    + "WHERE m.is_reviewer = true "
+                    + "JOIN member m ON r.member_id = m.id "
+                    + "WHERE m.is_reviewer = true AND r.id > :latestId "
                     + makeWhereClause(categoryId, tagIds)
-                    + "ORDER BY r.id "
-                    + "LIMIT :limit OFFSET :offset "
+                    + "GROUP BY r.id "
+                    + "LIMIT :limit "
                     + ") subquery"
                 + ")";
         final SqlParameterSource params = new MapSqlParameterSource("limit", pageable.getPageSize() + 1)
-                .addValue("offset", pageable.getOffset())
+                .addValue("latestId", pageable.getPageNumber())
                 .addValue("categoryId", categoryId)
                 .addValue("tagIds", tagIds);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,9 @@ spring:
       settings:
         web-allow-others: true
 
+  flyway:
+    enabled: false
+
 logging:
   level:
     org.hibernate.type.descriptor.sql: trace

--- a/src/test/java/project/reviewing/integration/member/application/MemberQueryServiceTest.java
+++ b/src/test/java/project/reviewing/integration/member/application/MemberQueryServiceTest.java
@@ -268,7 +268,12 @@ public class MemberQueryServiceTest extends IntegrationTest {
             );
 
             final ReviewersResponse response1 = memberQueryService.findReviewers(PageRequest.of(0, 2), backend.getId(), null);
-            final ReviewersResponse response2 = memberQueryService.findReviewers(PageRequest.of(1, 2), backend.getId(), null);
+            final ReviewersResponse response2 = memberQueryService.findReviewers(
+                    PageRequest.of(
+                            response1.getReviewers().get(response1.getReviewers().size() - 1).getId().intValue(), 2
+                    ),
+                    backend.getId(), null
+            );
 
             assertThat(response1.getReviewers()).hasSize(2)
                     .usingRecursiveFieldByFieldElementComparator()


### PR DESCRIPTION
## 상세 내용

- 리뷰어 목록 조회 쿼리 개선
   - Offset 방식 -> No Offset 방식인 Where절에 조건을 추가하는 방식으로 변경
   - IN + Subquery -> 별개의 쿼리로 분리 후 쿼리의 결과 값을 IN에 명시하는 방식으로 변경
   - DISTINCT + ORDER BY -> GROUP BY 사용으로 변경
- 추가로 Reviewer Id로 Member를 조회하는 JPQL 쿼리에서 Fetch Join을 적용하여 2개의 쿼리가 아닌 하나의 쿼리로 수행하도록 개선
- Reviewer Entity에 ColumnDefault 설정

## 주의 사항

<br/>

Close #93