### PR TITLE
[#94] Refresh Token 관리 방식 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	/* 테스트용 내장 Redis 환경 구성 */
+	implementation ('it.ozimov:embedded-redis:0.7.3') { exclude group: "org.slf4j", module: "slf4j-simple" }
+
 	/* JWT */
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
@@ -39,7 +42,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'it.ozimov:embedded-redis:0.7.3' // 테스트 용도로 내장 서버 Redis 환경 구성
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	/* JWT */
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -38,6 +39,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'it.ozimov:embedded-redis:0.7.3' // 테스트 용도로 내장 서버 Redis 환경 구성
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/src/main/java/project/reviewing/auth/domain/RefreshToken.java
+++ b/src/main/java/project/reviewing/auth/domain/RefreshToken.java
@@ -1,34 +1,27 @@
 package project.reviewing.auth.domain;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity
+@RedisHash("refreshToken")
 public class RefreshToken {
 
     @Id
-    @Column(name = "member_id")
-    private Long id;
+    private final Long memberId;
 
-    @Column(nullable = false, unique = true)
-    private String token;
+    private final String token;
 
-    @Column(nullable = false)
-    private LocalDateTime issuedAt;
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private final long validTime;
 
-    public RefreshToken(final Long memberId, final String token, final Long issuedAt) {
-        this.id = memberId;
+    public RefreshToken(final Long memberId, final String token, final long validTime) {
+        this.memberId = memberId;
         this.token = token;
-        this.issuedAt = LocalDateTime.ofInstant(Instant.ofEpochMilli(issuedAt), TimeZone.getDefault().toZoneId());
+        this.validTime = validTime;
     }
 }

--- a/src/main/java/project/reviewing/auth/infrastructure/TokenProvider.java
+++ b/src/main/java/project/reviewing/auth/infrastructure/TokenProvider.java
@@ -29,7 +29,7 @@ public class TokenProvider {
         this.accessTokenSecretKey = Keys.hmacShaKeyFor(accessTokenSecretKey.getBytes(StandardCharsets.UTF_8));
         this.refreshTokenSecretKey = Keys.hmacShaKeyFor(refreshTokenSecretKey.getBytes(StandardCharsets.UTF_8));
         this.accessTokenValidTime = accessTokenValidTime;
-        this. refreshTokenValidTime = refreshTokenValidTime;
+        this.refreshTokenValidTime = refreshTokenValidTime;
     }
 
     public String createAccessToken(final Long memberId) {
@@ -38,7 +38,7 @@ public class TokenProvider {
 
     public RefreshToken createRefreshToken(final Long memberId) {
         return new RefreshToken(
-                memberId, createJwt(memberId, refreshTokenValidTime, refreshTokenSecretKey), new Date().getTime()
+                memberId, createJwt(memberId, refreshTokenValidTime, refreshTokenSecretKey), refreshTokenValidTime
         );
     }
 

--- a/src/main/java/project/reviewing/common/config/EmbeddedRedisServerConfig.java
+++ b/src/main/java/project/reviewing/common/config/EmbeddedRedisServerConfig.java
@@ -1,0 +1,98 @@
+package project.reviewing.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+import redis.embedded.RedisServer;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * 로컬 실행 환경과 테스트 환경에서 내장 Redis를 사용하기 위한 설정
+ */
+
+@Profile({"!dev", "!prod"})
+@Configuration
+public class EmbeddedRedisServerConfig {
+
+    private final RedisServer redisServer;
+
+    public EmbeddedRedisServerConfig(@Value("${spring.redis.port}") final int redisPort) throws IOException {
+        int port = isRedisRunning(redisPort) ? findAvailablePort() : redisPort;
+        this.redisServer = RedisServer.builder()
+                .port(port)
+                .setting("maxmemory 10M")
+                .build();
+    }
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        this.redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        this.redisServer.stop();
+    }
+
+    /**
+     * Embedded Redis가 현재 실행중인지 확인
+     */
+    private boolean isRedisRunning(final int redisPort) throws IOException {
+        return isRunning(executeGrepProcessCommand(redisPort));
+    }
+
+    /**
+     * 현재 PC/서버에서 사용가능한 포트 확인하여 반환
+     */
+    public int findAvailablePort() throws IOException {
+
+        for (int port = 10000; port <= 65535; port++) {
+            Process process = executeGrepProcessCommand(port);
+            if (!isRunning(process)) {
+                return port;
+            }
+        }
+
+        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
+    }
+
+    /**
+     * 해당 port를 사용중인 프로세스 확인하는 sh 실행
+     */
+    private Process executeGrepProcessCommand(int port) throws IOException {
+        String os = System.getProperty("os.name").toLowerCase();
+
+        if (os.contains("win")) {
+            //log.info("OS is  " + OS + " " + port);
+            String command = String.format("netstat -nao | find \"LISTEN\" | find \"%d\"", port);
+            String[] shell = {"cmd.exe", "/y", "/c", command};
+            return Runtime.getRuntime().exec(shell);
+        }
+        String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
+        String[] shell = {"/bin/sh", "-c", command};
+        return Runtime.getRuntime().exec(shell);
+    }
+
+    /**
+     * 해당 Process가 현재 실행중인지 확인
+     */
+    private boolean isRunning(Process process) {
+        String line;
+        StringBuilder pidInfo = new StringBuilder();
+
+        try (BufferedReader input = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            while ((line = input.readLine()) != null) {
+                pidInfo.append(line);
+            }
+        } catch (Exception e) {
+            // log.debug();
+        }
+        return !StringUtils.isEmpty(pidInfo.toString());
+    }
+}

--- a/src/main/java/project/reviewing/common/config/RedisConfig.java
+++ b/src/main/java/project/reviewing/common/config/RedisConfig.java
@@ -1,0 +1,56 @@
+package project.reviewing.common.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+import java.util.Arrays;
+
+@EnableRedisRepositories
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    @Autowired
+    private Environment environment;
+
+    /**
+     * 내장 혹은 외부의 Redis를 연결
+     */
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+
+        // redis password 설정
+        Arrays.stream(environment.getActiveProfiles()).forEach(profile -> {
+            if (profile.equals("dev") || profile.equals("prod")) {
+                redisStandaloneConfiguration.setPassword(password);
+            }
+        });
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?,?> redisTemplate(){
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,6 +17,11 @@ spring:
         show_sql: true
         format_sql: true
 
+  redis:
+    host: ${redis.dev.host}
+    port: ${redis.dev.port}
+    password: ${redis.dev.password}
+
 logging:
   level:
     org.hibernate.type.descriptor.sql: trace

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -17,6 +17,11 @@ spring:
         show_sql: true
         format_sql: true
 
+  redis:
+    host: ${redis.prod.host}
+    port: ${redis.prod.port}
+    password: ${redis.prod.password}
+
 logging:
   level:
     org.hibernate.type.descriptor.sql: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,11 @@ spring:
       settings:
         web-allow-others: true
 
+  redis:
+    host: localhost
+    port: 6379
+    password:
+
   flyway:
     enabled: false
 

--- a/src/test/java/project/reviewing/integration/IntegrationTest.java
+++ b/src/test/java/project/reviewing/integration/IntegrationTest.java
@@ -1,14 +1,12 @@
 package project.reviewing.integration;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.context.annotation.Import;
-import org.springframework.stereotype.Repository;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 import project.reviewing.auth.domain.RefreshTokenRepository;
-import project.reviewing.common.util.ReviewingTime;
 import project.reviewing.common.util.Time;
 import project.reviewing.evaluation.command.domain.Evaluation;
 import project.reviewing.evaluation.command.domain.EvaluationRepository;
@@ -18,7 +16,6 @@ import project.reviewing.member.command.domain.MemberRepository;
 import project.reviewing.member.command.domain.Reviewer;
 import project.reviewing.member.query.dao.MyInformationDao;
 import project.reviewing.member.query.dao.ReviewerDao;
-import project.reviewing.review.scheduler.ReviewScheduler;
 import project.reviewing.review.command.domain.Review;
 import project.reviewing.review.query.dao.ReviewDAO;
 import project.reviewing.review.query.dao.ReviewsDAO;
@@ -29,8 +26,10 @@ import project.reviewing.tag.command.domain.TagRepository;
 import project.reviewing.tag.query.dao.TagDao;
 import project.reviewing.review.command.domain.ReviewRepository;
 
-@DataJpaTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = Repository.class))
-@Import({ReviewScheduler.class, ReviewingTime.class})
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Transactional
+@AutoConfigureTestDatabase
+@AutoConfigureTestEntityManager
 public abstract class IntegrationTest {
 
     @Autowired

--- a/src/test/java/project/reviewing/integration/auth/domain/RefreshTokenRepositoryTest.java
+++ b/src/test/java/project/reviewing/integration/auth/domain/RefreshTokenRepositoryTest.java
@@ -1,0 +1,36 @@
+package project.reviewing.integration.auth.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import project.reviewing.auth.domain.RefreshToken;
+import project.reviewing.auth.domain.RefreshTokenRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("RefreshTokenRepository는 ")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class RefreshTokenRepositoryTest {
+
+    @Autowired
+    protected RefreshTokenRepository refreshTokenRepository;
+
+    @DisplayName("RefreshToken을 저장하고, 저장된 데이터는 정해진 시간 이후 삭제된다.")
+    @Test
+    void saveTest() throws InterruptedException {
+        RefreshToken refreshToken1 = new RefreshToken(1L, "tokenString", 1000L);
+        RefreshToken refreshToken2 = new RefreshToken(2L, "tokenString", 3000L);
+
+        refreshTokenRepository.save(refreshToken1);
+        refreshTokenRepository.save(refreshToken2);
+
+        Thread.sleep(1000L);
+
+        assertAll(
+                () -> assertThat(refreshTokenRepository.findById(1L)).isEmpty(),
+                () -> assertThat(refreshTokenRepository.findById(2L)).isNotEmpty()
+        );
+    }
+}

--- a/src/test/java/project/reviewing/unit/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/project/reviewing/unit/auth/presentation/AuthControllerTest.java
@@ -62,7 +62,7 @@ public class AuthControllerTest extends ControllerTest {
         final RefreshResponse newRefreshResponse = new RefreshResponse("New Access Token", "New Refresh Token");
 
         given(authService.refreshTokens(memberId)).willReturn(newRefreshResponse);
-        given(refreshTokenRepository.findById(refreshToken.getId())).willReturn(Optional.of(refreshToken));
+        given(refreshTokenRepository.findById(refreshToken.getMemberId())).willReturn(Optional.of(refreshToken));
 
         mockMvc.perform(post("/auth/refresh")
                         .header("Authorization", "Bearer " + refreshToken.getToken()))
@@ -80,7 +80,7 @@ public class AuthControllerTest extends ControllerTest {
         final RefreshResponse newRefreshResponse = new RefreshResponse("New Access Token", "New Refresh Token");
 
         given(authService.refreshTokens(memberId)).willReturn(newRefreshResponse);
-        given(refreshTokenRepository.findById(refreshToken.getId())).willReturn(Optional.of(refreshToken));
+        given(refreshTokenRepository.findById(refreshToken.getMemberId())).willReturn(Optional.of(refreshToken));
 
         mockMvc.perform(post("/auth/refresh")
                         .header("Authorization", "Bearer " + refreshToken.getToken()))
@@ -96,7 +96,7 @@ public class AuthControllerTest extends ControllerTest {
         final RefreshResponse newRefreshResponse = new RefreshResponse("New Access Token", "New Refresh Token");
 
         given(authService.refreshTokens(memberId)).willReturn(newRefreshResponse);
-        given(refreshTokenRepository.findById(refreshToken.getId())).willReturn(Optional.empty());
+        given(refreshTokenRepository.findById(refreshToken.getMemberId())).willReturn(Optional.empty());
 
         mockMvc.perform(post("/auth/refresh")
                         .header("Authorization", "Bearer " + refreshToken.getToken()))

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -14,6 +14,11 @@ spring:
         show_sql: true
         format_sql: true
 
+  redis:
+    host: localhost
+    port: 6379
+    password:
+
   profiles:
     include: security
 


### PR DESCRIPTION
## 상세 내용

- Refresh Token 저장소 MySQL -> Redis로 변경
   - 관련 의존성, 설정 파일 추가 및 기존 로직 변경
   - 로컬 실행 환경 및 테스트 환경에서 사용할 Embedded Redis Server 환경 구성

## 주의 사항

- security 파일에 Redis 연결 정보 추가 필요

Close #94