### PR TITLE
[#95] 리뷰 데이터 배치 작업 개선

### DIFF
--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -127,16 +127,6 @@ public class Review {
         }
     }
 
-    public boolean isTimeToChangeToRefusedStatus() {
-        return (status == ReviewStatus.CREATED || status == ReviewStatus.ACCEPTED)
-                && isExpired();
-    }
-
-    public boolean isTimeToRemove() {
-        return (status == ReviewStatus.REFUSED || status == ReviewStatus.APPROVED || status == ReviewStatus.EVALUATED)
-                && isExpired();
-    }
-
     public LocalDateTime findExpireDate() {
         return statusSetAt.plusDays(status.getExpirePeriod());
     }
@@ -163,11 +153,6 @@ public class Review {
         if (status != ReviewStatus.APPROVED) {
             throw new InvalidReviewException(ErrorType.NOT_PROPER_REVIEW_STATUS);
         }
-    }
-
-    private boolean isExpired() {
-        LocalDateTime expireDate = findExpireDate();
-        return expireDate.isBefore(LocalDateTime.now()) || expireDate.isEqual(LocalDateTime.now());
     }
 
     private Review(

--- a/src/main/java/project/reviewing/review/command/domain/ReviewRepository.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewRepository.java
@@ -1,9 +1,11 @@
 package project.reviewing.review.command.domain;
 
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,4 +16,38 @@ public interface ReviewRepository extends Repository<Review, Long> {
     Optional<Review> findById(Long id);
     Optional<Review> findByRevieweeIdAndReviewerId(Long revieweeId, Long reviewerId);
     void delete(Review entity);
+
+    @Transactional
+    @Modifying
+    @Query(
+            "UPDATE Review r " +
+            "SET r.status = :refused, r.statusSetAt = CURRENT_TIMESTAMP " +
+            "WHERE (:startId < r.id AND r.id <= :endId) " +
+                    "AND (" +
+                        "(r.status = :created AND r.statusSetAt <= :createdExpiredTime) " +
+                        "OR (r.status = :accepted AND r.statusSetAt <= :acceptedExpiredTime) " +
+                    ")"
+    )
+    int updateExpiredReviews(
+            Long startId, Long endId,
+            ReviewStatus refused, ReviewStatus created, ReviewStatus accepted,
+            LocalDateTime createdExpiredTime, LocalDateTime acceptedExpiredTime
+    );
+
+    @Transactional
+    @Modifying
+    @Query(
+            "DELETE FROM Review r " +
+            "WHERE (:startId < r.id AND r.id <= :endId) " +
+                    "AND (" +
+                        "(r.status = :refused AND r.statusSetAt <= :refusedExpiredTime) " +
+                        "OR (r.status = :approved AND r.statusSetAt <= :approvedExpiredTime) " +
+                        "OR (r.status = :evaluated AND r.statusSetAt <= :evaluatedExpiredTime) " +
+                    ")"
+    )
+    int deleteExpiredReviews(
+            Long startId, Long endId,
+            ReviewStatus refused, ReviewStatus approved, ReviewStatus evaluated,
+            LocalDateTime refusedExpiredTime, LocalDateTime approvedExpiredTime, LocalDateTime evaluatedExpiredTime
+    );
 }

--- a/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
@@ -1,33 +1,73 @@
 package project.reviewing.review.scheduler;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import project.reviewing.common.util.Time;
+import project.reviewing.member.command.domain.MemberRepository;
 import project.reviewing.review.command.domain.Review;
 import project.reviewing.review.command.domain.ReviewRepository;
+import project.reviewing.review.command.domain.ReviewStatus;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.TypedQuery;
+import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 @RequiredArgsConstructor
 @Component
 public class ReviewScheduler {
 
+    private static final int BATCH_SIZE = 10000;
+
     private final ReviewRepository reviewRepository;
     private final Time time;
 
-    @Transactional
-    @Scheduled(cron = "${schedule.cron}")
-    public void checkExpirationForAllReview() {
-        final List<Review> reviews = reviewRepository.findAll();
+    @PersistenceContext
+    private final EntityManager em;
 
-        for (Review review : reviews) {
-            if (review.isTimeToChangeToRefusedStatus()) {
-                review.refuse(time);
-            } else if (review.isTimeToRemove()) {
-                reviewRepository.delete(review);
+    @Scheduled(cron = "${schedule.cron}")
+    public void handleExpiredReviews() {
+
+        LocalDateTime createdExpired = time.now().minusDays(ReviewStatus.CREATED.getExpirePeriod());
+        LocalDateTime acceptedExpired = time.now().minusDays(ReviewStatus.ACCEPTED.getExpirePeriod());
+        LocalDateTime refusedExpired = time.now().minusDays(ReviewStatus.REFUSED.getExpirePeriod());
+        LocalDateTime approvedExpired = time.now().minusDays(ReviewStatus.APPROVED.getExpirePeriod());
+        LocalDateTime evaluatedExpired = time.now().minusDays(ReviewStatus.EVALUATED.getExpirePeriod());
+
+        List<Long> list = em.createQuery("SELECT id FROM Review r", Long.class)
+                .getResultList();
+
+        Collections.sort(list);
+
+        long startId = 0;
+        long endId = 0;
+        long maxIdx = (list.size() % BATCH_SIZE == 0) ? 0 : list.size() + BATCH_SIZE;
+
+        for (int i = BATCH_SIZE - 1; i < maxIdx; i += BATCH_SIZE) {
+            if (i < list.size()) {
+                endId = list.get(i);
+            } else {
+                endId = list.get(list.size() - 1);
             }
+
+            reviewRepository.updateExpiredReviews(
+                    startId, endId, ReviewStatus.REFUSED, ReviewStatus.CREATED, ReviewStatus.ACCEPTED,
+                    createdExpired, acceptedExpired
+            );
+            reviewRepository.deleteExpiredReviews(
+                    startId, endId, ReviewStatus.REFUSED, ReviewStatus.APPROVED, ReviewStatus.EVALUATED,
+                    refusedExpired, approvedExpired, evaluatedExpired
+            );
+            startId = endId;
         }
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,4 +24,4 @@ spring:
 
 logging:
   level:
-    org.hibernate.type.descriptor.sql: trace
+    org.hibernate.type.descriptor.sql: debug

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,7 @@ spring:
     group:
       "default": "security"
       "dev": "dev, security"
+      "local": "local, security"
       "prod": "prod, security"
 
 schedule:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       "prod": "prod, security"
 
 schedule:
-  cron: 0/30 * * * * *
+  cron: 0 0/10 * * * *
 
 ---
 

--- a/src/test/java/project/reviewing/integration/review/scheduler/ReviewSchedulerTest.java
+++ b/src/test/java/project/reviewing/integration/review/scheduler/ReviewSchedulerTest.java
@@ -25,7 +25,7 @@ public class ReviewSchedulerTest extends IntegrationTest {
     @Mock
     private Time time;
 
-    @DisplayName("주기적으로 checkExpirationForAllReview() Method를 호출한다.")
+    @DisplayName("주기적으로 handleExpiredReviews();() Method를 호출한다.")
     @Test
     void workScheduledTask() {
         try {
@@ -34,7 +34,7 @@ public class ReviewSchedulerTest extends IntegrationTest {
             e.printStackTrace();
         }
 
-        verify(reviewScheduler, atLeast(2)).checkExpirationForAllReview();
+        verify(reviewScheduler, atLeast(2)).handleExpiredReviews();
     }
 
     @DisplayName("완료/평가 된 리뷰 중 완료 시점부터 일정 기간이 지나면 삭제한다.")
@@ -56,7 +56,7 @@ public class ReviewSchedulerTest extends IntegrationTest {
         entityManager.clear();
 
         // when
-        reviewScheduler.checkExpirationForAllReview();
+        reviewScheduler.handleExpiredReviews();
 
         // then
         assertThat(reviewRepository.findAll()).hasSize(1);
@@ -77,7 +77,7 @@ public class ReviewSchedulerTest extends IntegrationTest {
         entityManager.clear();
 
         // when
-        reviewScheduler.checkExpirationForAllReview();
+        reviewScheduler.handleExpiredReviews();
 
         // then
         assertThat(reviewRepository.findAll()).hasSize(1);
@@ -98,7 +98,7 @@ public class ReviewSchedulerTest extends IntegrationTest {
         entityManager.clear();
 
         // when
-        reviewScheduler.checkExpirationForAllReview();
+        reviewScheduler.handleExpiredReviews();
 
         // then
         final List<Review> reviews = reviewRepository.findAll();


### PR DESCRIPTION
## 상세 내용

- 벌크 연산 쿼리 적용
- 배치 작업 10000개씩 실행하도록 분할
- 작업 주기 '30초' -> '10분'으로 변경
- 'local' 환경 Profile 설정

## 주의 사항

<br/>

Close #95