### PR TITLE
[#99] 동시성 제어

### DIFF
--- a/src/main/java/project/reviewing/common/exception/ErrorType.java
+++ b/src/main/java/project/reviewing/common/exception/ErrorType.java
@@ -24,6 +24,7 @@ public enum ErrorType {
     REVIEWER_NOT_FOUND("MEMBER-006", "해당 회원의 리뷰어 정보를 찾을 수 없습니다."),
     ALREADY_REGISTERED("MEMBER-007", "이미 리뷰어 등록이 되었습니다."),
     DO_NOT_REGISTERED("MEMBER-008", "리뷰어 등록을 하지 않았습니다. 먼저 리뷰어 등록을 해주세요."),
+    REVIEWER_NOT_ACTIVE("MEMBER-009", "현재 리뷰어로 활동하고 있지 않습니다."),
 
     REVIEW_NOT_FOUND("REVIEW-001", "해당 리뷰를 찾을 수 없습니다."),
     ALREADY_REQUESTED("REVIEW-002", "이미 해당 리뷰어에게 리뷰를 요청했습니다."),

--- a/src/main/java/project/reviewing/common/exception/ErrorType.java
+++ b/src/main/java/project/reviewing/common/exception/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
     ERROR("COMMON-001", "구체적으로 정의되지 않은 내부 오류입니다."),
     INVALID_FORMAT("COMMON-002", "요청 형식이 유효하지 않습니다."),
     API_FAILED("COMMON-003", "API 요청에 실패했습니다."),
+    CONCURRENCY_COLLISION("COMMON-004", "요청이 실패했습니다. 다시 요청해 주세요."),
 
     NOT_AUTHENTICATED("AUTH-001", "인증되지 않은 요청입니다."),
     ALREADY_AUTHENTICATED("AUTH-002", "이미 인증 되었습니다."),

--- a/src/main/java/project/reviewing/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/project/reviewing/common/exception/GlobalControllerAdvice.java
@@ -1,6 +1,8 @@
 package project.reviewing.common.exception;
 
 import javax.persistence.OptimisticLockException;
+import javax.persistence.PersistenceException;
+import javax.persistence.PessimisticLockException;
 import javax.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -51,8 +53,8 @@ public class GlobalControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(OptimisticLockException.class)
-    public ErrorResponse handleOptimisticLockException(final OptimisticLockException e) {
+    @ExceptionHandler({OptimisticLockException.class, PessimisticLockException.class})
+    public ErrorResponse handleOptimisticLockException(final PersistenceException e) {
         return new ErrorResponse(ErrorType.CONCURRENCY_COLLISION.getCode(), ErrorType.CONCURRENCY_COLLISION.getMessage());
     }
 

--- a/src/main/java/project/reviewing/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/project/reviewing/common/exception/GlobalControllerAdvice.java
@@ -1,5 +1,6 @@
 package project.reviewing.common.exception;
 
+import javax.persistence.OptimisticLockException;
 import javax.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -47,6 +48,12 @@ public class GlobalControllerAdvice {
     @ExceptionHandler(ConstraintViolationException.class)
     public ErrorResponse handleConstraintViolationException(final ConstraintViolationException e) {
         return new ErrorResponse(ErrorType.ERROR.getCode(), ErrorType.ERROR.getCode() + " " + e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(OptimisticLockException.class)
+    public ErrorResponse handleOptimisticLockException(final OptimisticLockException e) {
+        return new ErrorResponse(ErrorType.CONCURRENCY_COLLISION.getCode(), ErrorType.CONCURRENCY_COLLISION.getMessage());
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/project/reviewing/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/project/reviewing/common/exception/GlobalControllerAdvice.java
@@ -4,6 +4,10 @@ import javax.persistence.OptimisticLockException;
 import javax.persistence.PersistenceException;
 import javax.persistence.PessimisticLockException;
 import javax.validation.ConstraintViolationException;
+
+import org.springframework.dao.ConcurrencyFailureException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -53,8 +57,11 @@ public class GlobalControllerAdvice {
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler({OptimisticLockException.class, PessimisticLockException.class})
-    public ErrorResponse handleOptimisticLockException(final PersistenceException e) {
+    @ExceptionHandler({
+            OptimisticLockException.class, PessimisticLockException.class,
+            OptimisticLockingFailureException.class, PessimisticLockingFailureException.class
+    })
+    public ErrorResponse handleLockException(final RuntimeException e) {
         return new ErrorResponse(ErrorType.CONCURRENCY_COLLISION.getCode(), ErrorType.CONCURRENCY_COLLISION.getMessage());
     }
 

--- a/src/main/java/project/reviewing/evaluation/command/application/EvaluationService.java
+++ b/src/main/java/project/reviewing/evaluation/command/application/EvaluationService.java
@@ -11,6 +11,7 @@ import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest
 import project.reviewing.member.command.domain.Member;
 import project.reviewing.member.command.domain.MemberRepository;
 import project.reviewing.member.exception.MemberNotFoundException;
+import project.reviewing.member.query.dao.MemberDao;
 import project.reviewing.review.command.domain.Review;
 import project.reviewing.review.command.domain.ReviewRepository;
 import project.reviewing.review.exception.ReviewNotFoundException;
@@ -20,7 +21,7 @@ import project.reviewing.review.exception.ReviewNotFoundException;
 @Service
 public class EvaluationService {
 
-    private final MemberRepository memberRepository;
+    private final MemberDao memberDao;
     private final ReviewRepository reviewRepository;
     private final EvaluationRepository evaluationRepository;
 
@@ -29,7 +30,7 @@ public class EvaluationService {
             final Long reviewerId,
             final EvaluationCreateRequest evaluationCreateRequest
     ) {
-        final Member reviewerMember = memberRepository.findByReviewerId(reviewerId)
+        final Member reviewerMember = memberDao.findByReviewerIdByXlockOnReviewer(reviewerId)
                 .orElseThrow(MemberNotFoundException::new);
         final Review review = reviewRepository.findById(evaluationCreateRequest.getReviewId())
                 .orElseThrow(ReviewNotFoundException::new);

--- a/src/main/java/project/reviewing/member/query/dao/MemberDao.java
+++ b/src/main/java/project/reviewing/member/query/dao/MemberDao.java
@@ -23,13 +23,13 @@ public class MemberDao {
         Map<String, Object> properties = new HashMap<>();
         properties.put("jakarta.persistence.lock.timeout", 3000L);
         Reviewer reviewer = em.find(Reviewer.class, reviewerId, LockModeType.PESSIMISTIC_READ, properties);
-        return Optional.of(reviewer.getMember());
+        return (reviewer != null) ? Optional.of(reviewer.getMember()) : Optional.empty();
     }
 
     public Optional<Member> findByReviewerIdByXlockOnReviewer(final long reviewerId) {
         Map<String, Object> properties = new HashMap<>();
         properties.put("jakarta.persistence.lock.timeout", 3000L);
         Reviewer reviewer = em.find(Reviewer.class, reviewerId, LockModeType.PESSIMISTIC_WRITE, properties);
-        return Optional.of(reviewer.getMember());
+        return (reviewer != null) ? Optional.of(reviewer.getMember()) : Optional.empty();
     }
 }

--- a/src/main/java/project/reviewing/member/query/dao/MemberDao.java
+++ b/src/main/java/project/reviewing/member/query/dao/MemberDao.java
@@ -1,0 +1,35 @@
+package project.reviewing.member.query.dao;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import project.reviewing.member.command.domain.Member;
+import project.reviewing.member.command.domain.Reviewer;
+
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+import javax.persistence.PersistenceContext;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class MemberDao {
+
+    @PersistenceContext
+    private final EntityManager em;
+
+    public Optional<Member> findByReviewerIdBySlockOnReviewer(final long reviewerId) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("jakarta.persistence.lock.timeout", 3000L);
+        Reviewer reviewer = em.find(Reviewer.class, reviewerId, LockModeType.PESSIMISTIC_READ, properties);
+        return Optional.of(reviewer.getMember());
+    }
+
+    public Optional<Member> findByReviewerIdByXlockOnReviewer(final long reviewerId) {
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("jakarta.persistence.lock.timeout", 3000L);
+        Reviewer reviewer = em.find(Reviewer.class, reviewerId, LockModeType.PESSIMISTIC_WRITE, properties);
+        return Optional.of(reviewer.getMember());
+    }
+}

--- a/src/main/java/project/reviewing/review/command/application/ReviewService.java
+++ b/src/main/java/project/reviewing/review/command/application/ReviewService.java
@@ -8,6 +8,7 @@ import project.reviewing.common.util.Time;
 import project.reviewing.member.command.domain.Member;
 import project.reviewing.member.command.domain.MemberRepository;
 import project.reviewing.member.exception.MemberNotFoundException;
+import project.reviewing.member.query.dao.MemberDao;
 import project.reviewing.review.command.application.response.SingleReviewReadResponse;
 import project.reviewing.review.command.domain.Review;
 import project.reviewing.review.command.domain.ReviewRepository;
@@ -25,6 +26,7 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final ReviewDAO reviewDAO;
     private final MemberRepository memberRepository;
+    private final MemberDao memberDao;
 
     private final Time time;
 
@@ -33,7 +35,7 @@ public class ReviewService {
             throw new InvalidReviewException(ErrorType.ALREADY_REQUESTED);
         }
 
-        final Member reviewerMember = memberRepository.findByReviewerId(reviewerId)
+        final Member reviewerMember = memberDao.findByReviewerIdBySlockOnReviewer(reviewerId)
                 .orElseThrow(MemberNotFoundException::new);
         final Review newReview = request.toEntity(
                 revieweeId, reviewerId, reviewerMember.getId(), reviewerMember.isReviewer(), time

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -53,7 +53,7 @@ public class Review {
             throw new InvalidReviewException(ErrorType.SAME_REVIEWER_AS_REVIEWEE);
         }
         if (!isReviewer) {
-            throw new InvalidReviewException(ErrorType.DO_NOT_REGISTERED);
+            throw new InvalidReviewException(ErrorType.REVIEWER_NOT_ACTIVE);
         }
 
         return new Review(revieweeId, reviewerId, title, content, prUrl, ReviewStatus.CREATED, time.now());

--- a/src/main/java/project/reviewing/review/command/domain/Review.java
+++ b/src/main/java/project/reviewing/review/command/domain/Review.java
@@ -41,6 +41,10 @@ public class Review {
     @Column(nullable = false)
     private LocalDateTime statusSetAt;
 
+    @Version
+    @Column(nullable = false)
+    private Integer version;
+
     public static Review assign(
             final Long revieweeId, final Long reviewerId, final String title, final String content,
             final String prUrl, final Long reviewerMemberId, final boolean isReviewer, Time time

--- a/src/main/java/project/reviewing/review/command/domain/ReviewRepository.java
+++ b/src/main/java/project/reviewing/review/command/domain/ReviewRepository.java
@@ -21,7 +21,7 @@ public interface ReviewRepository extends Repository<Review, Long> {
     @Modifying
     @Query(
             "UPDATE Review r " +
-            "SET r.status = :refused, r.statusSetAt = CURRENT_TIMESTAMP " +
+            "SET r.status = :refused, r.statusSetAt = CURRENT_TIMESTAMP, r.version = r.version + 1 " +
             "WHERE (:startId < r.id AND r.id <= :endId) " +
                     "AND (" +
                         "(r.status = :created AND r.statusSetAt <= :createdExpiredTime) " +

--- a/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
+++ b/src/main/java/project/reviewing/review/scheduler/ReviewScheduler.java
@@ -1,27 +1,20 @@
 package project.reviewing.review.scheduler;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 import project.reviewing.common.util.Time;
-import project.reviewing.member.command.domain.MemberRepository;
-import project.reviewing.review.command.domain.Review;
 import project.reviewing.review.command.domain.ReviewRepository;
 import project.reviewing.review.command.domain.ReviewStatus;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.TypedQuery;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 
+@Profile("!schedulerExclusion")
 @RequiredArgsConstructor
 @Component
 public class ReviewScheduler {

--- a/src/test/java/project/reviewing/concurrency/ConcurrencyRunnable.java
+++ b/src/test/java/project/reviewing/concurrency/ConcurrencyRunnable.java
@@ -1,0 +1,5 @@
+package project.reviewing.concurrency;
+
+public interface ConcurrencyRunnable {
+    void run();
+}

--- a/src/test/java/project/reviewing/concurrency/ConcurrencyRunner.java
+++ b/src/test/java/project/reviewing/concurrency/ConcurrencyRunner.java
@@ -1,0 +1,42 @@
+package project.reviewing.concurrency;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ConcurrencyRunner {
+
+    private final ExecutorService executorService;
+    private final CountDownLatch latch;
+    private final CyclicBarrier barrier;
+
+    public ConcurrencyRunner(int threadCnt) {
+        this.executorService = Executors.newFixedThreadPool(threadCnt);
+        this.latch = new CountDownLatch(threadCnt);
+        this.barrier = new CyclicBarrier(threadCnt);
+    }
+
+    public void execute(ConcurrencyRunnable func, long milliseconds) {
+        executorService.execute(() -> {
+            try {
+                barrier.await();
+                Thread.sleep(milliseconds);
+                func.run();
+            } catch (Exception e) {
+                e.printStackTrace();
+            } finally {
+                latch.countDown();
+            }
+        });
+    }
+
+    public void await(long milliseconds) {
+        try {
+            latch.await();
+            Thread.sleep(milliseconds);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/project/reviewing/concurrency/DatabaseCleaner.java
+++ b/src/test/java/project/reviewing/concurrency/DatabaseCleaner.java
@@ -2,8 +2,8 @@ package project.reviewing.concurrency;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 
-@ActiveProfiles("test")
+@Profile("databaseCleaner")
 @RequiredArgsConstructor
 @Component
 public class DatabaseCleaner implements InitializingBean {
@@ -23,7 +23,7 @@ public class DatabaseCleaner implements InitializingBean {
     private final List<String> tableNames = new ArrayList<>();
 
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
         for (Object[] tableInfo : tableInfos) {
             String tableName = (String) tableInfo[0];

--- a/src/test/java/project/reviewing/concurrency/DatabaseCleaner.java
+++ b/src/test/java/project/reviewing/concurrency/DatabaseCleaner.java
@@ -1,0 +1,42 @@
+package project.reviewing.concurrency;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+
+
+@ActiveProfiles("test")
+@RequiredArgsConstructor
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    private final List<String> tableNames = new ArrayList<>();
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        for (Object[] tableInfo : tableInfos) {
+            String tableName = (String) tableInfo[0];
+            tableNames.add(tableName);
+        }
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/test/java/project/reviewing/concurrency/member/MemberConcurrencyTest.java
+++ b/src/test/java/project/reviewing/concurrency/member/MemberConcurrencyTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import project.reviewing.common.util.Time;
 import project.reviewing.concurrency.ConcurrencyRunner;
 import project.reviewing.concurrency.DatabaseCleaner;
@@ -22,8 +23,9 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
 @DisplayName("Member Entity의 동시성 관련 상황에서는 ")
+@ActiveProfiles("databaseCleaner")
+@SpringBootTest
 public class MemberConcurrencyTest {
 
     @Autowired

--- a/src/test/java/project/reviewing/concurrency/member/MemberConcurrencyTest.java
+++ b/src/test/java/project/reviewing/concurrency/member/MemberConcurrencyTest.java
@@ -1,0 +1,146 @@
+package project.reviewing.concurrency.member;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import project.reviewing.common.util.Time;
+import project.reviewing.concurrency.ConcurrencyRunner;
+import project.reviewing.concurrency.DatabaseCleaner;
+import project.reviewing.evaluation.command.application.EvaluationService;
+import project.reviewing.evaluation.presentation.request.EvaluationCreateRequest;
+import project.reviewing.member.command.application.MemberService;
+import project.reviewing.member.command.domain.*;
+import project.reviewing.member.exception.MemberNotFoundException;
+import project.reviewing.review.command.application.ReviewService;
+import project.reviewing.review.command.domain.Review;
+import project.reviewing.review.command.domain.ReviewRepository;
+import project.reviewing.review.presentation.request.ReviewCreateRequest;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DisplayName("Member Entity의 동시성 관련 상황에서는 ")
+public class MemberConcurrencyTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private EvaluationService evaluationService;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private Time time;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void init() {
+        databaseCleaner.execute();
+    }
+
+    @DisplayName(
+            "동일한 Member에 대해 Member의 리뷰어 활동 상태를 수정하는 도중에 Review를 생성할 경우, "
+                    + "활동 상태가 변경 된 후 Review 생성 로직 내의 리뷰어 활동 상태 검증이 진행된다."
+    )
+    @Test
+    void CreateReviewAndUpdateMemberTest() {
+        int threadCnt = 2;
+        ConcurrencyRunner runner = new ConcurrencyRunner(threadCnt);
+
+        // given
+        Member reviewee = new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom");
+        Member reviewerMember = new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor");
+        Reviewer reviewer = new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글");
+        ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
+                "리뷰 요청합니다.", "본문", "https://github.com/Tom/myproject/pull/1"
+        );
+
+        reviewerMember.register(reviewer);
+
+        memberRepository.save(reviewee);
+        memberRepository.save(reviewerMember);
+
+        // when
+        runner.execute(() -> memberService.changeReviewerStatus(reviewerMember.getId()), 0);
+        runner.execute(() -> reviewService.createReview(reviewee.getId(), reviewer.getId(), reviewCreateRequest), 500);
+        runner.await(500);
+
+        //then
+        Member m = memberRepository.findById(reviewerMember.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        assertThat(reviewRepository.findAll()).isEmpty();
+        assertThat(m.isReviewer()).isFalse();
+    }
+
+    @DisplayName("동시에 동일한 리뷰어에게 평가하고 점수를 업데이트 하는 경우 차례대로 전부 반영된다.")
+    @Test
+    void UpdateScoreConcurrencyTest() {
+        int threadCnt = 2;
+        ConcurrencyRunner runner = new ConcurrencyRunner(threadCnt);
+
+        // given
+        Member reviewerMember = new Member(1L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor");
+        Reviewer reviewer = new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글");
+        Member reviewee1 = new Member(2L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom");
+        Member reviewee2 = new Member(3L, "Jack", "Jack@gmail.com", "imageUrl", "https://github.com/Jack");
+
+        reviewerMember.register(reviewer);
+
+        memberRepository.save(reviewerMember);
+        memberRepository.save(reviewee1);
+        memberRepository.save(reviewee2);
+
+        Review review1 = Review.assign(
+                reviewee1.getId(), reviewer.getId(), "제목", "본문",
+                "github.com/bboor/project/pull/1", reviewerMember.getId(), true, time
+        );
+        Review review2 = Review.assign(
+                reviewee2.getId(), reviewer.getId(), "제목", "본문",
+                "github.com/bboor/project/pull/1", reviewerMember.getId(), true, time
+        );
+
+        review1.approve(time);
+        review2.approve(time);
+
+        reviewRepository.save(review1);
+        reviewRepository.save(review2);
+
+        EvaluationCreateRequest evaluationCreateRequest1 = new EvaluationCreateRequest(
+                review1.getId(), 2.0f, "본문1"
+        );
+        EvaluationCreateRequest evaluationCreateRequest2 = new EvaluationCreateRequest(
+                review2.getId(), 4.0f, "본문2"
+        );
+
+        // when
+        runner.execute(
+                () -> evaluationService.createEvaluation(reviewee1.getId(), reviewer.getId(), evaluationCreateRequest1), 0
+        );
+        runner.execute(
+                () -> evaluationService.createEvaluation(reviewee2.getId(), reviewer.getId(), evaluationCreateRequest2), 0
+        );
+        runner.await(500);
+
+        //then
+        Member m = memberRepository.findById(reviewerMember.getId())
+                .orElseThrow(MemberNotFoundException::new);
+
+        assertThat(m.getReviewer().getEvaluationCnt()).isEqualTo(2);
+        assertThat(m.getReviewer().getScore()).isEqualTo(3.0f);
+    }
+}

--- a/src/test/java/project/reviewing/concurrency/review/ReviewConcurrencyTest.java
+++ b/src/test/java/project/reviewing/concurrency/review/ReviewConcurrencyTest.java
@@ -1,26 +1,32 @@
 package project.reviewing.concurrency.review;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import project.reviewing.common.util.Time;
 import project.reviewing.concurrency.ConcurrencyRunner;
+import project.reviewing.concurrency.DatabaseCleaner;
 import project.reviewing.member.command.domain.*;
-import project.reviewing.review.command.application.ReviewService;
 import project.reviewing.review.command.domain.Review;
 import project.reviewing.review.command.domain.ReviewRepository;
+import project.reviewing.review.command.domain.ReviewStatus;
 import project.reviewing.review.exception.ReviewNotFoundException;
+import project.reviewing.review.scheduler.ReviewScheduler;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
-@SpringBootTest
-@AutoConfigureTestEntityManager
 @DisplayName("Review Entity의 동시성 관련 상황에서는 ")
+@ActiveProfiles({"schedulerExclusion", "databaseCleaner"})
+@SpringBootTest
 public class ReviewConcurrencyTest {
 
     @Autowired
@@ -32,12 +38,23 @@ public class ReviewConcurrencyTest {
     @Autowired
     private Time time;
 
+    @Mock
+    private Time customTime;
+
     @PersistenceUnit
     private EntityManagerFactory emf;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @BeforeEach
+    void init() {
+        databaseCleaner.execute();
+    }
+
     @DisplayName("Review Entity를 동시에 수정하면 처음 수정 내용만 반영되고 version이 하나만 증가한다.")
     @Test
-    void ChangeReviewStatusConcurrencyTest() throws InterruptedException {
+    void ChangeReviewStatusConcurrencyTest() {
         // given
         int threadCnt = 3;
         ConcurrencyRunner runner = new ConcurrencyRunner(threadCnt);
@@ -66,8 +83,8 @@ public class ReviewConcurrencyTest {
 
                 try {
                     transaction.begin();
-                    em.merge(review);
                     review.evaluate();
+                    em.merge(review);
                     em.flush();
                     transaction.commit();
                 } catch (Exception e) {
@@ -75,15 +92,76 @@ public class ReviewConcurrencyTest {
                 } finally {
                     em.close();
                 }
-                em.close();
             }, 0);
         }
         runner.await(500);
 
+        //then
         Review updatedReview = reviewRepository.findById(review.getId())
                 .orElseThrow(ReviewNotFoundException::new);
 
-        //then
         assertThat(updatedReview.getVersion()).isEqualTo(1);
+        assertThat(updatedReview.getStatus()).isEqualTo(ReviewStatus.EVALUATED);
+    }
+
+    @DisplayName(
+            "ACCEPT 상태에서 만료된 Review Entity를 리뷰어가 APPROVE 상태로 변경하는 동시에 " +
+                    "Scheduler가 REFUSED 상태로 변경하는 상황에서" +
+                    "첫 번째 로직에서 Entity 조회 후 로직이 완료되기 전에 두번째 로직이 완료되는 경우, " +
+                    "첫 번째 로직이 실패하고 상태는 REFUSED 상태로 변경된다."
+    )
+    @Test
+    void ChangeReviewStatusAndSchedulerTest() {
+        // given
+        int threadCnt = 2;
+        ConcurrencyRunner runner = new ConcurrencyRunner(threadCnt);
+        ReviewScheduler reviewScheduler = new ReviewScheduler(reviewRepository, time, emf.createEntityManager());
+
+        given(customTime.now()).willReturn(LocalDateTime.now().minusDays(10));
+
+        Member reviewee = new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom");
+        Member reviewerMember = new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor");
+        Reviewer reviewer = new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글");
+
+        reviewerMember.register(reviewer);
+
+        memberRepository.save(reviewee);
+        memberRepository.save(reviewerMember);
+
+        Review review = Review.assign(
+                reviewee.getId(), reviewer.getId(), "제목", "본문",
+                "github.com/bboor/project/pull/1", reviewerMember.getId(), true, time
+        );
+
+        review.accept(customTime);
+        reviewRepository.save(review);
+
+        // when
+        runner.execute(() -> {
+            EntityManager em = emf.createEntityManager();
+            EntityTransaction transaction = em.getTransaction();
+
+            try {
+                transaction.begin();
+                Review approvingReview = em.find(Review.class, review.getId());
+                Thread.sleep(500);
+                approvingReview.approve(time);
+                em.flush();
+                transaction.commit();
+            } catch (Exception e) {
+                transaction.rollback();
+            } finally {
+                em.close();
+            }
+        }, 0);
+        runner.execute(reviewScheduler::handleExpiredReviews, 0);
+        runner.await(500);
+
+        // then
+        Review updatedReview = reviewRepository.findById(review.getId())
+                .orElseThrow(ReviewNotFoundException::new);
+
+        assertThat(updatedReview.getVersion()).isEqualTo(1);
+        assertThat(updatedReview.getStatus()).isEqualTo(ReviewStatus.REFUSED);
     }
 }

--- a/src/test/java/project/reviewing/concurrency/review/ReviewConcurrencyTest.java
+++ b/src/test/java/project/reviewing/concurrency/review/ReviewConcurrencyTest.java
@@ -1,0 +1,100 @@
+package project.reviewing.concurrency.review;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import project.reviewing.common.util.Time;
+import project.reviewing.member.command.domain.*;
+import project.reviewing.review.command.domain.Review;
+import project.reviewing.review.command.domain.ReviewRepository;
+import project.reviewing.review.exception.ReviewNotFoundException;
+
+import javax.persistence.*;
+import java.util.Set;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@AutoConfigureTestEntityManager
+@DisplayName("Review Entity의 동시성 관련 상황에서는 ")
+public class ReviewConcurrencyTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private Time time;
+
+    @PersistenceUnit
+    private EntityManagerFactory emf;
+
+    @DisplayName("Review Entity를 동시에 수정하면 처음 수정 내용만 반영되고 version이 하나만 증가한다.")
+    @Test
+    void test() throws InterruptedException {
+        // given
+        int threadCnt = 3;
+
+        CountDownLatch latch = new CountDownLatch(threadCnt);
+        CyclicBarrier barrier = new CyclicBarrier(threadCnt);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCnt);
+
+        Member reviewee = new Member(1L, "Tom", "Tom@gmail.com", "imageUrl", "https://github.com/Tom");
+        Member reviewerMember = new Member(2L, "bboor", "bboor@gmail.com", "imageUrl", "https://github.com/bboor");
+        Reviewer reviewer = new Reviewer(Job.BACKEND, Career.JUNIOR, Set.of(1L), "소개글");
+
+        reviewerMember.register(reviewer);
+
+        memberRepository.save(reviewee);
+        memberRepository.save(reviewerMember);
+
+        Review review = Review.assign(
+                reviewee.getId(), reviewer.getId(), "제목", "본문",
+                "github.com/bboor/project/pull/1", reviewerMember.getId(), true, time
+        );
+
+        reviewRepository.save(review);
+
+        // when
+        while (threadCnt-- > 0) {
+            executorService.execute(() -> {
+                EntityManager em = emf.createEntityManager();
+                EntityTransaction transaction = em.getTransaction();
+
+                try {
+                    transaction.begin();
+                    System.out.println(transaction);
+                    Review updatingReview = reviewRepository.findById(review.getId())
+                            .orElseThrow(ReviewNotFoundException::new);
+                    updatingReview.accept(time);
+                    em.merge(updatingReview);
+
+                    barrier.await();
+                    latch.countDown();
+
+                    em.flush();
+                    transaction.commit();
+                } catch (Exception e) {
+                    transaction.rollback();
+                } finally {
+                    em.close();
+                }
+                em.close();
+            });
+        }
+
+        latch.await();
+        Thread.sleep(500);
+
+        Review updatedReview = reviewRepository.findById(review.getId())
+                .orElseThrow(ReviewNotFoundException::new);
+
+        //then
+        assertThat(updatedReview.getVersion()).isEqualTo(1);
+    }
+}

--- a/src/test/java/project/reviewing/integration/IntegrationTest.java
+++ b/src/test/java/project/reviewing/integration/IntegrationTest.java
@@ -14,6 +14,7 @@ import project.reviewing.evaluation.query.dao.EvaluationsDAO;
 import project.reviewing.member.command.domain.Member;
 import project.reviewing.member.command.domain.MemberRepository;
 import project.reviewing.member.command.domain.Reviewer;
+import project.reviewing.member.query.dao.MemberDao;
 import project.reviewing.member.query.dao.MyInformationDao;
 import project.reviewing.member.query.dao.ReviewerDao;
 import project.reviewing.review.command.domain.Review;
@@ -52,6 +53,9 @@ public abstract class IntegrationTest {
 
     @Autowired
     protected Time time;
+
+    @Autowired
+    protected MemberDao memberDao;
 
     @Autowired
     protected MyInformationDao myInformationDao;

--- a/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
+++ b/src/test/java/project/reviewing/integration/evaluation/application/EvaluationServiceTest.java
@@ -32,7 +32,7 @@ public class EvaluationServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        evaluationService = new EvaluationService(memberRepository, reviewRepository, evaluationRepository);
+        evaluationService = new EvaluationService(memberDao, reviewRepository, evaluationRepository);
     }
 
     @DisplayName("리뷰 평가 생성 시 ")

--- a/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
+++ b/src/test/java/project/reviewing/integration/review/application/ReviewServiceTest.java
@@ -30,7 +30,7 @@ public class ReviewServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        reviewService = new ReviewService(reviewRepository, reviewDAO, memberRepository, time);
+        reviewService = new ReviewService(reviewRepository, reviewDAO, memberRepository, memberDao, time);
     }
 
     @DisplayName("리뷰 생성 시 ")

--- a/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
+++ b/src/test/java/project/reviewing/unit/review/domain/ReviewTest.java
@@ -44,7 +44,7 @@ public class ReviewTest {
     void createWithNotRegisteredReviewer() {
         assertThatThrownBy(() -> Review.assign(1L, 2L, "제목", "본문", "github.com/bboor/project/pull/1", 2L, false, time))
                 .isInstanceOf(InvalidReviewException.class)
-                .hasMessage(ErrorType.DO_NOT_REGISTERED.getMessage());
+                .hasMessage(ErrorType.REVIEWER_NOT_ACTIVE.getMessage());
     }
 
     @DisplayName("리뷰를 수정할 수 있다.")


### PR DESCRIPTION
## 상세 내용

- Review Entity에 낙관적 락 적용
   - Review 수정 벌크 연산 쿼리에 낙관적 락 version 증가 내용 추가
   - 테스트 상황
      - 동시에 Review Entity를 수정하는 상황
         - 하나의 수정 내용만 반영되어야 한다.
      - 스케쥴러와 유저가 Review를 동시에 수정하는 상황
         - Service 로직 내에서 Review Entity 조회 후 스케쥴러 로직이 완료되는 상황
         - 스케쥴러의 수정 내용만 반영되고 Service 로직은 실패해야 한다.
- Reviewer Entity에 비관적 락 적용
   - 테스트 상황
      - Reviewer에게 리뷰를 요청하는 동시에 Reviewer의 활동 상태가 꺼지는 상황
         - 리뷰 요청이 실패해야 한다.
      - 여러명의 Reviewee가 동시에 같은 Reviewer에 대한 평가를 작성하는 상황
         - 누락없이 모든 평가 점수와 내용이 반영되어야 한다.
- 테스트 관련 @Profile 적용
   - 각 테스트마다 DB 데이터를 삭제해주기 위한 DatabaseCleaner class 추가하고 @Profile을 통해 사용할 수 있도록 설정
   - 테스트 과정에서 스케쥴러 Bean이 등록되지 않도록 @Profile 추가
- 동시성 테스트를 실행하기 위한 class를 따로 추가하여 반복 코드 제거 및 가독성, 유연성, 확장성 개선

Close #99